### PR TITLE
Fixing OS X Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ matrix:
       file: 'release_windows.zip'
 
     - os: osx
-      osx_image: xcode7.3
+      # osx_image: xcode7.3
+      osx_image: xcode9.2
       env: VERGE_PLATFORM='mac'
       compiler: clang 
       file: 'release_mac.zip'
@@ -40,8 +41,7 @@ deploy:
     secure: "2MFTd9bXbZlwLMh+/KkJWrUA5KKeGrpZCw/5iybkzPFhUYv2znskQia0XHnj5VIDNCC7a+CtmIz07ZEI7B3uB+UISCgpZ8ifmPGfGeuy0VI2qt+CZ0Z34oMsJNUkCFYLgGbi0/ro2lKL7BmSxClVHtfYgyxo/yLeTO9f7Q08CKPmb5Nv4EKycZq6rzA02UScRjiIHWfKZ6fDsCecV6CYJSoKsuOfw54/1HBzh/iFtywQCjCrBOQwpPI11kO6GbrcTfYqz1c4Va6QVuDtH7yzW1VqEZHHnPDb6H+YEofVRhJAw3jHyisU/r6I3mnV1KaPkNW0iifRaQrFBYv9RWBhBuRJNGh1QwcTHhrDKxkF4IHBMbFjeeHrm07RTMT9Yp8tZbpF9Mc3KdMQBwOQhXWB7KvMYdcFpEKm5dfwcWqEl//YWBMvKf0EE7/vnTWDkEq7vn8ompRxqlPiLgkK2bqRtHrYFo5dtrY5BIDr7CCkL1XAiUCCZ2B5lezOwOzea/thUL+q2M8rELKjrXUFHehcIqRqs9JRXaiig10BKRKYlp+R/Sw/GFvh5xr0ALtV6rCzkfJlMdXqO3TXxQf/ZAV95tIafBEoBlQENqutMMDpNM2vrNrl6MIV1PNIfRREw5HSLJUmtP1H130EmhOX9PHZhGqZPIi1aRd6j0kXIwFURyw="
   skip_cleanup: true
   on:
-    # TODO: change me vergeDEV
-    repo: mkinney/VERGE
+    repo: vergcurrency/VERGE
     tags: true
     all_branches: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ matrix:
       file: 'release_windows.zip'
 
     - os: osx
-      # osx_image: xcode7.3
       osx_image: xcode9.2
       env: VERGE_PLATFORM='mac'
       compiler: clang 

--- a/building/mac/build.sh
+++ b/building/mac/build.sh
@@ -1,8 +1,8 @@
 
-export PKG_CONFIG_PATH=/usr/local/qt5/5.4/clang_64/lib/pkgconfig
-export PATH=/usr/local/qt5/5.4/clang_64/bin:$PATH
-export QT_CFLAGS="-I/usr/local/qt5/5.4/clang_64/lib/QtWebKitWidgets.framework/Versions/5/Headers -I/usr/local/qt5/5.4/clang_64/lib/QtWebView.framework/Versions/5/Headers -I/usr/local/qt5/5.4/clang_64/lib/QtDBus.framework/Versions/5/Headers -I/usr/local/qt5/5.4/clang_64/lib/QtWidgets.framework/Versions/5/Headers -I/usr/local/qt5/5.4/clang_64/lib/QtWebKit.framework/Versions/5/Headers -I/usr/local/qt5/5.4/clang_64/lib/QtNetwork.framework/Versions/5/Headers -I/usr/local/qt5/5.4/clang_64/lib/QtGui.framework/Versions/5/Headers -I/usr/local/qt5/5.4/clang_64/lib/QtCore.framework/Versions/5/Headers -I. -I/usr/local/qt5/5.4/clang_64/mkspecs/macx-clang -F/usr/local/qt5/5.4/clang_64/lib"
-export QT_LIBS="-F/usr/local/qt5/5.4/clang_64/lib -framework QtWidgets -framework QtGui -framework QtCore -framework DiskArbitration -framework IOKit -framework OpenGL -framework AGL -framework QtNetwork -framework QtWebKit -framework QtWebKitWidgets -framework QtDBus -framework QtWebView"
+export PKG_CONFIG_PATH=/usr/local/opt/qt@5.5/lib/pkgconfig
+export PATH=/usr/local/opt/qt@5.5/bin:$PATH
+export QT_CFLAGS="-I/usr/local/opt/qt@5.5/lib/QtWebKitWidgets.framework/Versions/5/Headers -I/usr/local/opt/qt@5.5/lib/QtDBus.framework/Versions/5/Headers -I/usr/local/opt/qt@5.5/lib/QtWidgets.framework/Versions/5/Headers -I/usr/local/opt/qt@5.5/lib/QtWebKit.framework/Versions/5/Headers -I/usr/local/opt/qt@5.5/lib/QtNetwork.framework/Versions/5/Headers -I/usr/local/opt/qt@5.5/lib/QtGui.framework/Versions/5/Headers -I/usr/local/opt/qt@5.5/lib/QtCore.framework/Versions/5/Headers -I. -I/usr/local/opt/qt@5.5/mkspecs/macx-clang -F/usr/local/opt/qt@5.5/lib"
+export QT_LIBS="-F/usr/local/opt/qt@5.5/lib -framework QtWidgets -framework QtGui -framework QtCore -framework DiskArbitration -framework IOKit -framework OpenGL -framework AGL -framework QtNetwork -framework QtWebKit -framework QtWebKitWidgets -framework QtDBus"
 
 ./autogen.sh
 ./configure --with-gui=qt5

--- a/building/mac/dist.sh
+++ b/building/mac/dist.sh
@@ -10,7 +10,7 @@ sudo easy_install appscript
 # fix for the 'Error: No file at /opt/local/lib/mysql55/mysql/libmysqlclient.18.dylib' issue
 brew install mysql
 pwd
-cd /usr/local/qt5/5.4/clang_64/plugins/sqldrivers
+cd /usr/local/opt/qt@5.5/plugins/sqldrivers
 echo "before:"
 otool -L libqsqlmysql.dylib
 install_name_tool -change /opt/local/lib/mysql55/mysql/libmysqlclient.18.dylib /usr/local/Cellar/mysql/5.7.11/lib/libmysqlclient.20.dylib libqsqlmysql.dylib

--- a/building/mac/requirements.sh
+++ b/building/mac/requirements.sh
@@ -1,8 +1,4 @@
-#brew install boost pkg-config 
 brew uninstall qt5
-brew install protobuf miniupnpc openssl qrencode berkeley-db4 
-# Might need these later: libevent librsvg
-curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/fdfc724dd532345f5c6cdf47dc43e99654e6a5fd/Formula/qt5.rb
-brew install ./qt5.rb
-brew link --force qt5
+brew install boost pkg-config
+brew install qt@5.5 protobuf miniupnpc openssl qrencode berkeley-db4 automake
 


### PR DESCRIPTION
This PR:

- updates the build to use a newer version of Xcode in Travis
- Fixes build scripts so they work on OS X 10.12
- Removes the need to download the old ruby homebrew install script