### PR TITLE
fix for issue 166 (mac qt download link & version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 ```
 ____   _________________________   ________ ___________
 \   \ /   /\_   _____/\______   \ /  _____/ \_   _____/
- \   Y   /  |    __)_  |       _//   \  ___  |    __)_ 
+ \   Y   /  |    __)_  |       _//   \  ___  |    __)_
   \     /   |        \ |    |   \\    \_\  \ |        \ 2017 VERGE/XVG
    \___/   /_______  / |____|_  / \______  //_______  /
-                   \/         \/         \/         \/ 
+                   \/         \/         \/         \/
 ```
 VERGE [XVG] Source Code
 ================================
@@ -20,7 +20,7 @@ Specifications:
 * Blocktime: 30 seconds
 * RPC port: 20102
 * P2P port: 21102
-* Blockreward: 
+* Blockreward:
   * Block 0 to 14,000 : 200,000 coins
   * 14,000 to 28,000 : 100,000 coins
   * 28,000 to 42,000: 50,000 coins
@@ -38,7 +38,7 @@ Approximately total reward cap: 16.5 Billion
 
 Binary (pre-compiled) wallets are available on all platforms at [https://vergecurrency.com](https://vergecurrency.com/#wallets)
 
-Compiling Linux Wallet on Ubuntu/Debian (faster) 
+Compiling Linux Wallet on Ubuntu/Debian (faster)
 ----------------------
 
 ```shell
@@ -50,7 +50,7 @@ sudo apt-get -y install git && cd ~ && git clone https://github.com/vergecurrenc
 Compiling Linux Wallet on Ubuntu/Debian
 ----------------------
 
-Step 1. Install the dependencies. 
+Step 1. Install the dependencies.
 
 ```shell
 sudo add-apt-repository ppa:bitcoin/bitcoin
@@ -107,7 +107,7 @@ rpcpassword=85CpSuCNvDcYsdQU8w621mkQqJAimSQwCSJL5dPT9wQX
 
 **Optional**: Add `rpcport=20102`, `port=21102`, or `algo=groestl` to the configuration file.
 
-Add `daemon=1`. 
+Add `daemon=1`.
 
 Your config may look something like this:
 
@@ -120,7 +120,7 @@ daemon=1
 algo=groestl
 ```
 
-Exit the VERGE.conf by pressing `ctrl + x` on your keyboard then pressing `y` and hitting enter. This should have created a VERGE.conf file with what you just added. 
+Exit the VERGE.conf by pressing `ctrl + x` on your keyboard then pressing `y` and hitting enter. This should have created a VERGE.conf file with what you just added.
 
 Type `VERGEd.exe` (or `./VERGEd` if on mac or linux) and your verge daemon should start.
 
@@ -132,27 +132,27 @@ To compile on Mac (OSX El Capitan, but test compiled on Mountain Lion v10.8):
 ------------
 1. Ensure you do not have qt5 nor qt installed.
 
-    `brew uninstall qt qt5 qt55 qt52`   
-   
-2. Download [qt5.4.2](https://download.qt.io/official_releases/qt/5.4/5.4.2/qt-opensource-mac-x64-clang-5.4.2.dmg)
-     
+    `brew uninstall qt qt5 qt55 qt52`
+
+2. Download [qt5.5.0](https://download.qt.io/archive/qt/5.5/5.5.0/qt-opensource-mac-x64-clang-5.5.0.dmg)
+
 3. Install qt5 into `/usr/local/qt5`
 
-   Note: Change the installation folder from `xxx/Qt5.4.2` to `/usr/local/qt5`
-   
+   Note: Change the installation folder from `xxx/Qt5.5.0` to `/usr/local/qt5`
+
 4. Run these commands:
 
     ```shell
-    export PKG_CONFIG_PATH=/usr/local/qt5/5.4/clang_64/lib/pkgconfig    
-    export PATH=/usr/local/qt5/5.4/clang_64/bin:$PATH
-    export QT_CFLAGS="-I/usr/local/qt5/5.4/clang_64/lib/QtWebKitWidgets.framework/Versions/5/Headers -I/usr/local/qt5/5.4/clang_64/lib/QtWebView.framework/Versions/5/Headers -I/usr/local/qt5/5.4/clang_64/lib/QtDBus.framework/Versions/5/Headers -I/usr/local/qt5/5.4/clang_64/lib/QtWidgets.framework/Versions/5/Headers -I/usr/local/qt5/5.4/clang_64/lib/QtWebKit.framework/Versions/5/Headers -I/usr/local/qt5/5.4/clang_64/lib/QtNetwork.framework/Versions/5/Headers -I/usr/local/qt5/5.4/clang_64/lib/QtGui.framework/Versions/5/Headers -I/usr/local/qt5/5.4/clang_64/lib/QtCore.framework/Versions/5/Headers -I. -I/usr/local/qt5/5.4/clang_64/mkspecs/macx-clang -F/usr/local/qt5/5.4/clang_64/lib"
-    export QT_LIBS="-F/usr/local/qt5/5.4/clang_64/lib -framework QtWidgets -framework QtGui -framework QtCore -framework DiskArbitration -framework IOKit -framework OpenGL -framework AGL -framework QtNetwork -framework QtWebKit -framework QtWebKitWidgets -framework QtDBus -framework QtWebView"
+    export PKG_CONFIG_PATH=/usr/local/qt5/5.5/clang_64/lib/pkgconfig
+    export PATH=/usr/local/qt5/5.5/clang_64/bin:$PATH
+    export QT_CFLAGS="-I/usr/local/qt5/5.5/clang_64/lib/QtWebKitWidgets.framework/Versions/5/Headers -I/usr/local/qt5/5.5/clang_64/lib/QtWebView.framework/Versions/5/Headers -I/usr/local/qt5/5.5/clang_64/lib/QtDBus.framework/Versions/5/Headers -I/usr/local/qt5/5.5/clang_64/lib/QtWidgets.framework/Versions/5/Headers -I/usr/local/qt5/5.5/clang_64/lib/QtWebKit.framework/Versions/5/Headers -I/usr/local/qt5/5.5/clang_64/lib/QtNetwork.framework/Versions/5/Headers -I/usr/local/qt5/5.5/clang_64/lib/QtGui.framework/Versions/5/Headers -I/usr/local/qt5/5.5/clang_64/lib/QtCore.framework/Versions/5/Headers -I. -I/usr/local/qt5/5.5/clang_64/mkspecs/macx-clang -F/usr/local/qt5/5.5/clang_64/lib"
+    export QT_LIBS="-F/usr/local/qt5/5.5/clang_64/lib -framework QtWidgets -framework QtGui -framework QtCore -framework DiskArbitration -framework IOKit -framework OpenGL -framework AGL -framework QtNetwork -framework QtWebKit -framework QtWebKitWidgets -framework QtDBus -framework QtWebView"
     ```
 
 5. Install the other required items:
 
     `brew install protobuf boost miniupnpc openssl qrencode berkeley-db4 automake`
-    
+
 6. Download the wallet source and build:
 
     ```shell
@@ -202,7 +202,7 @@ http://108.61.216.160/cryptochainer.chains/chains/Verge_blockchain.zip
 
 Want to 'solo-mine' from the wallet?
 ----------
-You can use the wallet to mine. You need to specify the algorithm (see below) and set the "gen" flag. For instance, in the configuration specify `gen=1`. 
+You can use the wallet to mine. You need to specify the algorithm (see below) and set the "gen" flag. For instance, in the configuration specify `gen=1`.
 
 
 Using different algorithms (for mining)


### PR DESCRIPTION
- fix mac qt download link
- update qt version to match version in build.sh
- remove extra trailing whitespaces