### PR TITLE
remove unwanted UI element on new address

### DIFF
--- a/src/qt/editaddressdialog.cpp
+++ b/src/qt/editaddressdialog.cpp
@@ -19,9 +19,10 @@ EditAddressDialog::EditAddressDialog(Mode mode, QWidget *parent) :
     case NewReceivingAddress:
         setWindowTitle(tr("New receiving address"));
         ui->addressEdit->setEnabled(false);
-		ui->addressEdit->setVisible(false);
-		ui->stealthCB->setEnabled(true);
-		ui->stealthCB->setVisible(true);
+        ui->addressEdit->setVisible(false);
+        ui->addressEditLabel->setVisible(false);
+        ui->stealthCB->setEnabled(true);
+        ui->stealthCB->setVisible(true);
         break;
     case NewSendingAddress:
         setWindowTitle(tr("New sending address"));

--- a/src/qt/forms/editaddressdialog.ui
+++ b/src/qt/forms/editaddressdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>457</width>
-    <height>126</height>
+    <height>173</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -46,16 +46,6 @@ max-height: 25px;</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>&amp;Address</string>
-       </property>
-       <property name="buddy">
-        <cstring>addressEdit</cstring>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="1">
       <widget class="QLineEdit" name="addressEdit">
        <property name="toolTip">
@@ -73,12 +63,9 @@ max-height: 25px;</string>
        </property>
       </widget>
      </item>
-	 <item row="2" column="0">
+     <item row="2" column="0">
       <widget class="QCheckBox" name="stealthCB">
-       <property name="text">
-        <string>Stealth Address</string>
-       </property>
-	   <property name="styleSheet">
+       <property name="styleSheet">
         <string notr="true">
 border-top-left-radius: 5px;
 border-top-right-radius: 5px;
@@ -87,6 +74,19 @@ border-bottom-right-radius: 5px;
 border: 2px solid #000000;
 min-height: 25px;
 max-height: 25px;</string>
+       </property>
+       <property name="text">
+        <string>Stealth Address</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="addressEditLabel">
+       <property name="text">
+        <string>&amp;Address</string>
+       </property>
+       <property name="buddy">
+        <cstring>addressEdit</cstring>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Currently (after we removed the address from new address dialog) the "Address" label is unwanted
<img width="460" alt="screen shot 2018-01-03 at 12 08 56 am" src="https://user-images.githubusercontent.com/34992411/34549851-dc4d3a9c-f0d9-11e7-9c26-4b6b2604b02d.png">

After this change:
<img width="462" alt="screen shot 2018-01-03 at 10 48 30 pm" src="https://user-images.githubusercontent.com/34992411/34549859-ed1c4f16-f0d9-11e7-9dc4-ff96b319b180.png">

Also, edit address will work normally (this PR does not affect this) 

<img width="454" alt="screen shot 2018-01-03 at 10 48 41 pm" src="https://user-images.githubusercontent.com/34992411/34549861-f9eef248-f0d9-11e7-9630-da5e1e943ca1.png">


