### PR TITLE
Fix about dialog

### DIFF
--- a/src/qt/forms/aboutdialog.ui
+++ b/src/qt/forms/aboutdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>593</width>
-    <height>319</height>
+    <height>442</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,7 +23,7 @@
       </sizepolicy>
      </property>
      <property name="pixmap">
-      <pixmap resource="../bitcoin.qrc">:/images/about</pixmap>
+      <pixmap>:/images/about</pixmap>
      </property>
     </widget>
    </item>
@@ -138,19 +138,13 @@ HTP!</string>
        </property>
       </spacer>
      </item>
-     <item>
+     <item alignment="Qt::AlignLeft">
       <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="autoFillBackground">
+        <bool>false</bool>
+       </property>
        <property name="styleSheet">
-        <string notr="true">
-border-top-left-radius: 5px;
-border-top-right-radius: 5px;
-border-bottom-left-radius: 5px;
-border-bottom-right-radius: 5px;
-border: 1px solid #0b3b47;
-min-height: 25px;
-max-height: 25px;
-min-width: 100px;
-max-width: 100px;</string>
+        <string notr="true"/>
        </property>
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -164,9 +158,7 @@ max-width: 100px;</string>
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="../bitcoin.qrc"/>
- </resources>
+ <resources/>
  <connections>
   <connection>
    <sender>buttonBox</sender>

--- a/src/qt/forms/aboutdialog.ui
+++ b/src/qt/forms/aboutdialog.ui
@@ -7,8 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>593</width>
-    <height>442</height>
+    <height>495</height>
    </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>593</width>
+    <height>495</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>About VERGE</string>
@@ -138,7 +144,7 @@ HTP!</string>
        </property>
       </spacer>
      </item>
-     <item alignment="Qt::AlignLeft">
+     <item>
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="autoFillBackground">
         <bool>false</bool>


### PR DESCRIPTION
Before:
<img width="596" alt="screen shot 2018-01-03 at 11 24 36 pm" src="https://user-images.githubusercontent.com/34992411/34550812-c4d1be76-f0e1-11e7-8f65-883c02722fc5.png">

After:
<img width="597" alt="screen shot 2018-01-03 at 11 55 16 pm" src="https://user-images.githubusercontent.com/34992411/34550816-d21cb4b4-f0e1-11e7-99dc-7a1ddfbdf959.png">


Removed the stylesheet from the button. It's causing buttons to look like label, the default Qt styles look nicer and has a clickable feel to it (hoping we could keep this consistent throughout)
  