### PR TITLE
Removing compiler warnings

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1288,26 +1288,6 @@ void static ProcessOneShot()
     }
 }
 
-// ppcoin: stake minter thread
-void static ThreadStakeMinter(void* parg)
-{
-    printf("ThreadStakeMinter started\n");
-    CWallet* pwallet = (CWallet*)parg;
-    try
-    {
-        vnThreadsRunning[THREAD_MINTER]++;
-        VERGEMiner(pwallet, true);
-        vnThreadsRunning[THREAD_MINTER]--;
-    }
-    catch (std::exception& e) {
-        vnThreadsRunning[THREAD_MINTER]--;
-        PrintException(&e, "ThreadStakeMinter()");
-    } catch (...) {
-        vnThreadsRunning[THREAD_MINTER]--;
-        PrintException(NULL, "ThreadStakeMinter()");
-    }
-    printf("ThreadStakeMinter exiting, %d threads remaining\n", vnThreadsRunning[THREAD_MINTER]);
-}
 
 void ThreadOpenConnections2(void* parg)
 {
@@ -1864,6 +1844,7 @@ void StartNode(void* parg)
         printf("Error; NewThread(ThreadDumpAddress) failed\n");
 
     // ppcoin: mint proof-of-stake blocks in the background
+    // TODO: remove? or use ThreadVERGEMiner in main.cpp as it is a duplicated function of ThreadStakeMinter?
     //if (!NewThread(ThreadStakeMinter, pwalletMain))
     //    printf("Error: NewThread(ThreadStakeMinter) failed\n");
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -155,6 +155,8 @@ void SendCoinsDialog::on_sendButton_clicked()
             tr("Error: The transaction was rejected. This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here."),
             QMessageBox::Ok, QMessageBox::Ok);
         break;
+    case WalletModel::NarrationTooLong: //nothing to do? Added to avoid compiler warning
+        break;
     case WalletModel::Aborted: // User aborted, nothing to do
         break;
     case WalletModel::OK:

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -118,7 +118,6 @@ bool CWallet::Unlock(const SecureString& strWalletPassphrase)
 
 bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase, const SecureString& strNewWalletPassphrase)
 {
-    bool fWasLocked = IsLocked();
 
     {
         LOCK(cs_wallet);


### PR DESCRIPTION
This PR helps with removing few warnings during compilation.

Removed the currently unused ThreadStakeMinter as ThreadVERGEMiner does the exact same thing. If this was wrong to do, let me know.

/ Max