### PR TITLE
Missing dependancies: libseccomp-dev libcap-dev

### DIFF
--- a/doc/build-verge-linux.md
+++ b/doc/build-verge-linux.md
@@ -19,7 +19,7 @@ The _slightly_ longer version:
         libtool autotools-dev automake pkg-config libssl-dev zlib1g-dev libz-dev libevent-dev \
         bsdmainutils git libboost-all-dev libseccomp-dev libncap-dev libminiupnpc-dev libqt5gui5 \
         libqt5core5a libqt5webkit5-dev libqt5dbus5 qttools5-dev \
-        qttools5-dev-tools libprotobuf-dev protobuf-compiler libqrencode-dev
+        qttools5-dev-tools libprotobuf-dev protobuf-compiler libqrencode-dev libseccomp-dev libcap-dev
     ```
 
 2. Clone the git repository and compile the daemon and gui wallet:


### PR DESCRIPTION
Missing dependancies for installation on Ubuntu

Packages libseccomp-dev and libcap-dev are required on https://github.com/vergecurrency/VERGE/blob/master/README.md but not written in /doc/build-verge-linux.md

<!--- Provide a general summary of your changes in the Title above -->

## Description
Missing dependancies for Ubuntu

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Installation on Linux Ubuntu of new wallet.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Compilation worked fine with these packages.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
Documentation change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
