### PR TITLE
Clean up OS X Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ src/qt/VERGE-qt
 
 VERGEd
 VERGE-qt
+release_*.zip
 
 Makefile.in
 aclocal.m4

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Binary (pre-compiled) wallets are available on all platforms at [https://vergecu
 
 > **Note:** It may look like it is frozen or hung while it is indexing and syncing the blockchain. It's not. It's chugging away, but currently the UI doesn't give you a lot of feedback on status. We're working to fix that. Syncing takes a while to complete (ie. > 10 minutes or more) so just be patient.
 
-> **Note:** If you want to change your configuration you can create a `~/Library/Application\ Support/VERGE/VERGE.conf` file with your options. If you don, make sure to restart Verge. This isn't required and so there is no `VERGE.conf` file created by default.
+> **Note:** If you want to change your configuration you can create a `~/Library/Application\ Support/VERGE/VERGE.conf` file with your options. If you do, make sure to restart Verge. This isn't required and so there is no `VERGE.conf` file created by default.
 
 ### Linux Wallet
 

--- a/README.md
+++ b/README.md
@@ -84,20 +84,12 @@ Binary (pre-compiled) wallets are available on all platforms at [https://vergecu
 1. Download the pre-compiled software.
 2. Double click the DMG
 3. Drag the Verge-Qt to your Applications folder
-4. Install required `boost` dependency via homebrew
-
-    ```shell
-    xcode-select --install
-    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-    brew doctor
-    brew install boost
-    ```
-5. Double click the Verge-Qt application to open it.
-6. Go grab a :coffee: while it syncs with the blockchain
+4. Double click the Verge-Qt application to open it.
+5. Go grab a :coffee: while it syncs with the blockchain
 
 > **Note:** It may look like it is frozen or hung while it is indexing and syncing the blockchain. It's not. It's chugging away, but currently the UI doesn't give you a lot of feedback on status. We're working to fix that. Syncing takes a while to complete (ie. > 10 minutes or more) so just be patient.
 
-> **Note:** If you want to change your configuration the file is located at `~/Library/Application\ Support\VERGE\VERGE.conf`. This isn't required by default.
+> **Note:** If you want to change your configuration you can create a `~/Library/Application\ Support/VERGE/VERGE.conf` file with your options. If you don, make sure to restart Verge. This isn't required and so there is no `VERGE.conf` file created by default.
 
 ### Linux Wallet
 

--- a/building/mac/requirements.sh
+++ b/building/mac/requirements.sh
@@ -1,11 +1,15 @@
-# Remove any old qt5 lingering around
-brew uninstall qt5
-
-# Make sure we have the C libs we need
-brew install boost@1.60 pkg-config automake
-
-# Install some deps
-brew install qt@5.5 protobuf miniupnpc openssl qrencode berkeley-db4 zlib
+# Install our depdencies some deps
+brew install pkg-config \
+  automake \
+  boost@1.60 \
+  qt@5.5 \
+  protobuf \
+  miniupnpc \
+  openssl \
+  qrencode \
+  berkeley-db4 \
+  zlib \
+  libevent
 
 # Make sure our stuff is linked in our path
 brew link automake autoconf

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ define(_CLIENT_VERSION_REVISION, 1)
 define(_CLIENT_VERSION_BUILD, 0)
 define(_CLIENT_VERSION_IS_RELEASE, true)
 define(_COPYRIGHT_YEAR, 2018)
-AC_INIT([VERGE Core],[_CLIENT_VERSION_MAJOR._CLIENT_VERSION_MINOR._CLIENT_VERSION_REVISION],[https://github.com/vergecurrency/VERGE/issues],[verge],[http://VERGEcurrency.com/])
+AC_INIT([VERGE Core],[_CLIENT_VERSION_MAJOR._CLIENT_VERSION_MINOR._CLIENT_VERSION_REVISION],[https://github.com/vergecurrency/VERGE/issues],[verge],[https://vergecurrency.com/])
 AC_CONFIG_AUX_DIR([src/build-aux])
 AC_CONFIG_MACRO_DIR([src/m4])
 AC_CANONICAL_HOST
@@ -19,7 +19,7 @@ AX_SUBDIRS_CONFIGURE([tor], [[--disable-unittests], [--disable-system-torrc], [-
 # This m4 will only be used if a system copy cannot be found. This is helpful
 # on systems where autotools are installed but the pkg-config macros are not in
 # a default location. It is currently used for building on OSX where autotools
-# are preinstalled but pkg-config comes from macports or homebrew. It should
+# are preinstalled but pkg-config comes from homebrew. It should
 # probably be removed when building on <= 10.6 is no longer supported.
 m4_include([pkg.m4])
 
@@ -245,39 +245,27 @@ case $host in
      AC_SUBST(WINDOWS_BITS)
      ;;
   *darwin*)
-     TARGET_OS=darwin
-     LEVELDB_TARGET_FLAGS="TARGET_OS=Darwin"
-     if  test x$cross_compiling != xyes; then
-       BUILD_OS=darwin
-       AC_CHECK_PROG([PORT],port, port)
-       if test x$PORT = xport; then
-         dnl add default macports paths
-         CPPFLAGS="$CPPFLAGS -isystem /opt/local/include -I/opt/local/include/db48"
-         LIBS="$LIBS -L/opt/local/lib -L/opt/local/lib/db48"
-       fi
+    TARGET_OS=darwin
+    BUILD_OS=darwin
+    LEVELDB_TARGET_FLAGS="TARGET_OS=Darwin"
+    AC_CHECK_PROG([BREW], brew, brew)
+    
+    if test x$BREW = xbrew; then
+      dnl add default homebrew paths
+      openssl_prefix=`$BREW --prefix openssl`
+      bdb_prefix=`$BREW --prefix berkeley-db4`
+      boost_prefix=`$BREW --prefix boost@1.60`
+      export PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
+      CPPFLAGS="$CPPFLAGS -I$bdb_prefix/include -I$boost_prefix/include"
+      LIBS="$LIBS -L$bdb_prefix/lib -L$boost_prefix/lib"
+    fi
 
-       AC_CHECK_PROG([BREW],brew, brew)
-       if test x$BREW = xbrew; then
-         dnl add default homebrew paths
-         openssl_prefix=`$BREW --prefix openssl`
-         bdb_prefix=`$BREW --prefix berkeley-db4`
-         export PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
-         CPPFLAGS="$CPPFLAGS -I$bdb_prefix/include"
-         LIBS="$LIBS -L$bdb_prefix/lib"
-       fi
-     else
-       case $build_os in
-         *darwin*)
-           BUILD_OS=darwin
-           ;;
-         *)
-           AC_PATH_TOOL([INSTALLNAMETOOL], [install_name_tool], install_name_tool)
-           AC_PATH_TOOL([OTOOL], [otool], otool)
-           AC_PATH_PROGS([GENISOIMAGE], [genisoimage mkisofs],genisoimage)
-           ;;
-       esac
-     fi
+    AC_PATH_TOOL([INSTALLNAMETOOL], [install_name_tool], install_name_tool)
+    AC_PATH_TOOL([OTOOL], [otool], otool)
+    AC_PATH_PROGS([GENISOIMAGE], [genisoimage mkisofs],genisoimage)
 
+     # Enable c++11 on OS X
+     CXXFLAGS="$CXXFLAGS -std=c++11 -stdlib=libc++"
      CPPFLAGS="$CPPFLAGS -DMAC_OSX"
      ;;
    *)

--- a/doc/build-verge-osx.md
+++ b/doc/build-verge-osx.md
@@ -2,10 +2,10 @@
 
 > **Note:** This has only been confirmed to work on OS X Sierra (10.12) and OS X High Sierra (10.13) with XCode 9.2 and `Apple LLVM version 9.0.0 (clang-900.0.39.2)`.
 
-1. Ensure you have mysql and boost installed.
+1. Ensure you have mysql installed.
     
     ```shell
-    brew install mysql boost
+    brew install mysql
     ```
 
 2. Ensure you have python 2.7 installed and in your path (OS X comes with this by default)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1978,7 +1978,7 @@ bool CBlock::SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew)
         }
 
         if (!vpindexSecondary.empty())
-            printf("Postponing %"PRIszu" reconnects\n", vpindexSecondary.size());
+            printf("Postponing %" PRIszu " reconnects\n", vpindexSecondary.size());
 
         // Switch to new best branch
         if (!Reorganize(txdb, pindexIntermediate))

--- a/src/rpcsmessage.cpp
+++ b/src/rpcsmessage.cpp
@@ -805,7 +805,7 @@ Value smsgbuckets(const Array& params, bool fHelp)
                 std::string sBucket = boost::lexical_cast<std::string>(it->first);
                 std::string sFile = sBucket + "_01.dat";
                 
-                snprintf(cbuf, sizeof(cbuf), "%"PRIszu, tokenSet.size());
+                snprintf(cbuf, sizeof(cbuf), "%" PRIszu, tokenSet.size());
                 std::string snContents(cbuf);
                 
                 std::string sHash = boost::lexical_cast<std::string>(it->second.hash);

--- a/src/smessage.cpp
+++ b/src/smessage.cpp
@@ -194,7 +194,7 @@ void SecMsgBucket::hashBucket()
     hash = XXH32_digest(state);
     
     if (fDebug)
-        printf("Hashed %"PRIszu" messages, hash %u\n", setTokens.size(), hash);
+        printf("Hashed %" PRIszu " messages, hash %u\n", setTokens.size(), hash);
 };
 
 
@@ -612,7 +612,7 @@ void ThreadSecureMsg(void* parg)
         int64_t now = GetTime();
         
         if (fDebug)
-            printf("SecureMsgThread %"PRId64" \n", now);
+            printf("SecureMsgThread %" PRId64 " \n", now);
         
         int64_t cutoffTime = now - SMSG_RETENTION;
         
@@ -624,11 +624,11 @@ void ThreadSecureMsg(void* parg)
             while (it != smsgBuckets.end())
             {
                 //if (fDebug)
-                //    printf("Checking bucket %"PRId64", size %"PRIszu" \n", it->first, it->second.setTokens.size());
+                //    printf("Checking bucket %" PRId64 ", size %" PRIszu " \n", it->first, it->second.setTokens.size());
                 if (it->first < cutoffTime)
                 {
                     if (fDebug)
-                        printf("Removing bucket %"PRId64" \n", it->first);
+                        printf("Removing bucket %" PRId64 " \n", it->first);
                     std::string fileName = boost::lexical_cast<std::string>(it->first) + "_01.dat";
                     fs::path fullPath = GetDataDir() / "smsgStore" / fileName;
                     if (fs::exists(fullPath))
@@ -669,7 +669,7 @@ void ThreadSecureMsg(void* parg)
                             int64_t     ignoreUntil = GetTime() + SMSG_TIME_IGNORE;
                             
                             if (fDebug)
-                                printf("Lock on bucket %"PRId64" for peer %u timed out.\n", it->first, nPeerId);
+                                printf("Lock on bucket %" PRId64 " for peer %u timed out.\n", it->first, nPeerId);
                             // -- look through the nodes for the peer that locked this bucket
                             LOCK(cs_vNodes);
                             BOOST_FOREACH(CNode* pnode, vNodes)
@@ -685,7 +685,7 @@ void ThreadSecureMsg(void* parg)
                                 pnode->PushMessage("smsgIgnore", vchData);
                                 
                                 if (fDebug)
-                                    printf("This node will ignore peer %u until %"PRId64".\n", nPeerId, ignoreUntil);
+                                    printf("This node will ignore peer %u until %" PRId64 ".\n", nPeerId, ignoreUntil);
                                 break;
                             };
                             it->second.nLockPeerId = 0;
@@ -813,7 +813,7 @@ std::string fsReadable(uint64_t nBytes)
     if (nBytes >= 1024)
         snprintf(buffer, sizeof(buffer), "%.2f KB", nBytes/1024.0);
     else
-        snprintf(buffer, sizeof(buffer), "%"PRIu64" bytes", nBytes);
+        snprintf(buffer, sizeof(buffer), "%" PRIu64 " bytes", nBytes);
     return std::string(buffer);
 };
 
@@ -949,10 +949,10 @@ int SecureMsgBuildBucketSet()
         nMessages += tokenSet.size();
         
         if (fDebug)
-            printf("Bucket %"PRId64" contains %"PRIszu" messages.\n", fileTime, tokenSet.size());
+            printf("Bucket %" PRId64 " contains %" PRIszu " messages.\n", fileTime, tokenSet.size());
     };
     
-    printf("Processed %u files, loaded %"PRIszu" buckets containing %u messages.\n", nFiles, smsgBuckets.size(), nMessages);
+    printf("Processed %u files, loaded %" PRIszu " buckets containing %u messages.\n", nFiles, smsgBuckets.size(), nMessages);
     
     return 0;
 };
@@ -1066,7 +1066,7 @@ int SecureMsgReadIni()
         };
     };
     
-    printf("Loaded %"PRIszu" addresses.\n", smsgAddresses.size());
+    printf("Loaded %" PRIszu " addresses.\n", smsgAddresses.size());
     
     fclose(fp);
     
@@ -1357,7 +1357,7 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
         if (now < pfrom->smsgData.ignoreUntil)
         {
             if (fDebug)
-                printf("Node is ignoring peer %u until %"PRId64".\n", pfrom->smsgData.nPeerId, pfrom->smsgData.ignoreUntil);
+                printf("Node is ignoring peer %u until %" PRId64 ".\n", pfrom->smsgData.nPeerId, pfrom->smsgData.ignoreUntil);
             return false;
         };
         
@@ -1405,7 +1405,7 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
             if (time < now - SMSG_RETENTION)
             {
                 if (fDebug)
-                    printf("Not interested in peer bucket %"PRId64", has expired.\n", time);
+                    printf("Not interested in peer bucket %" PRId64 ", has expired.\n", time);
                 
                 if (time < now - SMSG_RETENTION - SMSG_TIME_LEEWAY)
                     pfrom->Misbehaving(1);
@@ -1414,7 +1414,7 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
             if (time > now + SMSG_TIME_LEEWAY)
             {
                 if (fDebug)
-                    printf("Not interested in peer bucket %"PRId64", in the future.\n", time);
+                    printf("Not interested in peer bucket %" PRId64 ", in the future.\n", time);
                 pfrom->Misbehaving(1);
                 continue;
             };
@@ -1422,14 +1422,14 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
             if (ncontent < 1)
             {
                 if (fDebug)
-                    printf("Peer sent empty bucket, ignore %"PRId64" %u %u.\n", time, ncontent, hash);
+                    printf("Peer sent empty bucket, ignore %" PRId64 " %u %u.\n", time, ncontent, hash);
                 continue;
             };
             
             if (fDebug)
             {
-                printf("peer bucket %"PRId64" %u %u.\n", time, ncontent, hash);
-                printf("this bucket %"PRId64" %"PRIszu" %u.\n", time, smsgBuckets[time].setTokens.size(), smsgBuckets[time].hash);
+                printf("peer bucket %" PRId64 " %u %u.\n", time, ncontent, hash);
+                printf("this bucket %" PRId64 " %" PRIszu " %u.\n", time, smsgBuckets[time].setTokens.size(), smsgBuckets[time].hash);
             };
             
             if (smsgBuckets[time].nLockCount > 0)
@@ -1447,7 +1447,7 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
                     && smsgBuckets[time].hash != hash)) // if same amount in buckets check hash
             {
                 if (fDebug)
-                    printf("Requesting contents of bucket %"PRId64".\n", time);
+                    printf("Requesting contents of bucket %" PRId64 ".\n", time);
                 
                 uint32_t sz = vchDataOut.size();
                 vchDataOut.resize(sz + 8);
@@ -1471,7 +1471,7 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
             memcpy(&vchDataOut[0], &now, 8);
             pfrom->PushMessage("smsgMatch", vchDataOut);
             if (fDebug)
-                printf("Sending smsgMatch, %"PRId64".\n", now);
+                printf("Sending smsgMatch, %" PRId64 ".\n", now);
         };
         
     } else
@@ -1506,7 +1506,7 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
             if (itb == smsgBuckets.end())
             {
                 if (fDebug)
-                    printf("Don't have bucket %"PRId64".\n", time);
+                    printf("Don't have bucket %" PRId64 ".\n", time);
                 continue;
             };
             
@@ -1515,7 +1515,7 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
             try {
                 vchDataOut.resize(8 + 16 * tokenSet.size());
             } catch (std::exception& e) {
-                printf("vchDataOut.resize %"PRIszu" threw: %s.\n", 8 + 16 * tokenSet.size(), e.what());
+                printf("vchDataOut.resize %" PRIszu " threw: %s.\n", 8 + 16 * tokenSet.size(), e.what());
                 continue;
             };
             memcpy(&vchDataOut[0], &time, 8);
@@ -1552,13 +1552,13 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
         if (time < now - SMSG_RETENTION)
         {
             if (fDebug)
-                printf("Not interested in peer bucket %"PRId64", has expired.\n", time);
+                printf("Not interested in peer bucket %" PRId64 ", has expired.\n", time);
             return false;
         };
         if (time > now + SMSG_TIME_LEEWAY)
         {
             if (fDebug)
-                printf("Not interested in peer bucket %"PRId64", in the future.\n", time);
+                printf("Not interested in peer bucket %" PRId64 ", in the future.\n", time);
             pfrom->Misbehaving(1);
             return false;
         };
@@ -1566,12 +1566,12 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
         if (smsgBuckets[time].nLockCount > 0)
         {
             if (fDebug)
-                printf("Bucket %"PRId64" lock count %u, waiting for message data from peer %u.\n", time, smsgBuckets[time].nLockCount, smsgBuckets[time].nLockPeerId);
+                printf("Bucket %" PRId64 " lock count %u, waiting for message data from peer %u.\n", time, smsgBuckets[time].nLockCount, smsgBuckets[time].nLockPeerId);
             return false;
         }; 
         
         if (fDebug)
-            printf("Sifting through bucket %"PRId64".\n", time);
+            printf("Sifting through bucket %" PRId64 ".\n", time);
         
         std::vector<unsigned char> vchDataOut;
         vchDataOut.resize(8);
@@ -1608,8 +1608,8 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
         {
             if (fDebug)
             {
-                printf("Asking peer for  %"PRIszu" messages.\n", (vchDataOut.size() - 8) / 16);
-                printf("Locking bucket %"PRIszu" for peer %u.\n", time, pfrom->smsgData.nPeerId);
+                printf("Asking peer for  %" PRIszu " messages.\n", (vchDataOut.size() - 8) / 16);
+                printf("Locking bucket %" PRIszu " for peer %u.\n", time, pfrom->smsgData.nPeerId);
             };
             smsgBuckets[time].nLockCount   = 3; // lock this bucket for at most 3 * SMSG_THREAD_DELAY seconds, unset when peer sends smsgMsg
             smsgBuckets[time].nLockPeerId  = pfrom->smsgData.nPeerId;
@@ -1640,7 +1640,7 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
         if (itb == smsgBuckets.end())
         {
             if (fDebug)
-                printf("Don't have bucket %"PRId64".\n", time);
+                printf("Don't have bucket %" PRId64 ".\n", time);
             return false;
         };
         
@@ -1657,12 +1657,12 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
             if (it == tokenSet.end())
             {
                 if (fDebug)
-                    printf("Don't have wanted message %"PRId64".\n", token.timestamp);
+                    printf("Don't have wanted message %" PRId64 ".\n", token.timestamp);
             } else
             {
-                //printf("Have message at %"PRId64".\n", it->offset); // DEBUG
+                //printf("Have message at %" PRId64 ".\n", it->offset); // DEBUG
                 token.offset = it->offset;
-                //printf("winb before SecureMsgRetrieve %"PRId64".\n", token.timestamp);
+                //printf("winb before SecureMsgRetrieve %" PRId64 ".\n", token.timestamp);
                 
                 // -- place in vchOne so if SecureMsgRetrieve fails it won't corrupt vchBunch
                 if (SecureMsgRetrieve(token, vchOne) == 0)
@@ -1671,14 +1671,14 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
                     vchBunch.insert(vchBunch.end(), vchOne.begin(), vchOne.end()); // append
                 } else
                 {
-                    printf("SecureMsgRetrieve failed %"PRId64".\n", token.timestamp);
+                    printf("SecureMsgRetrieve failed %" PRId64 ".\n", token.timestamp);
                 };
                 
                 if (nBunch >= 500
                     || vchBunch.size() >= 96000)
                 {
                     if (fDebug)
-                        printf("Break bunch %u, %"PRIszu".\n", nBunch, vchBunch.size());
+                        printf("Break bunch %u, %" PRIszu ".\n", nBunch, vchBunch.size());
                     break; // end here, peer will send more want messages if needed.
                 };
             };
@@ -1688,7 +1688,7 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
         if (nBunch > 0)
         {
             if (fDebug)
-                printf("Sending block of %u messages for bucket %"PRId64".\n", nBunch, time);
+                printf("Sending block of %u messages for bucket %" PRId64 ".\n", nBunch, time);
             
             memcpy(&vchBunch[0], &nBunch, 4);
             memcpy(&vchBunch[4], &time, 8);
@@ -1701,7 +1701,7 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
         vRecv >> vchData;
         
         if (fDebug)
-            printf("smsgMsg vchData.size() %"PRIszu".\n", vchData.size());
+            printf("smsgMsg vchData.size() %" PRIszu ".\n", vchData.size());
         
         SecureMsgReceive(pfrom, vchData);
     } else
@@ -1713,7 +1713,7 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
         
         if (vchData.size() < 8)
         {
-            printf("smsgMatch, not enough data %"PRIszu".\n", vchData.size());
+            printf("smsgMatch, not enough data %" PRIszu ".\n", vchData.size());
             pfrom->Misbehaving(1);
             return false;
         };
@@ -1724,7 +1724,7 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
         int64_t now = GetTime();
         if (time > now + SMSG_TIME_LEEWAY)
         {
-            printf("Warning: Peer buckets matched in the future: %"PRId64".\nEither this node or the peer node has the incorrect time set.\n", time);
+            printf("Warning: Peer buckets matched in the future: %" PRId64 ".\nEither this node or the peer node has the incorrect time set.\n", time);
             if (fDebug)
                 printf("Peer match time set to now.\n");
             time = now;
@@ -1733,7 +1733,7 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
         pfrom->smsgData.lastMatched = time;
         
         if (fDebug)
-            printf("Peer buckets matched at %"PRId64".\n", time);
+            printf("Peer buckets matched at %" PRId64 ".\n", time);
         
     } else
     if (strCommand == "smsgPing")
@@ -1767,7 +1767,7 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
         
         if (vchData.size() < 8)
         {
-            printf("smsgIgnore, not enough data %"PRIszu".\n", vchData.size());
+            printf("smsgIgnore, not enough data %" PRIszu ".\n", vchData.size());
             pfrom->Misbehaving(1);
             return false;
         };
@@ -1778,7 +1778,7 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
         pfrom->smsgData.ignoreUntil = time;
         
         if (fDebug)
-            printf("Peer %u is ignoring this node until %"PRId64", ignore peer too.\n", pfrom->smsgData.nPeerId, time);
+            printf("Peer %u is ignoring this node until %" PRId64 ", ignore peer too.\n", pfrom->smsgData.nPeerId, time);
     } else
     {
         // Unknown message
@@ -1827,7 +1827,7 @@ bool SecureMsgSendData(CNode* pto, bool fSendTrickle)
         
         if (fDebug)
             printf("SecureMsgSendData(): nWakeCounter expired, sending bucket inventory to %s.\n"
-            "Now %"PRId64" next wake counter %u\n", pto->addrName.c_str(), now, pto->smsgData.nWakeCounter);
+            "Now %" PRId64 " next wake counter %u\n", pto->addrName.c_str(), now, pto->smsgData.nWakeCounter);
     };
     pto->smsgData.nWakeCounter--;
     
@@ -1862,7 +1862,7 @@ bool SecureMsgSendData(CNode* pto, bool fSendTrickle)
                 try {
                     vchData.resize(vchData.size() + 16);
                 } catch (std::exception& e) {
-                    printf("vchData.resize %"PRIszu" threw: %s.\n", vchData.size() + 16, e.what());
+                    printf("vchData.resize %" PRIszu " threw: %s.\n", vchData.size() + 16, e.what());
                     continue;
                 };
                 memcpy(p, &it->first, 8);
@@ -1872,7 +1872,7 @@ bool SecureMsgSendData(CNode* pto, bool fSendTrickle)
                 p += 16;
                 nBucketsShown++;
                 //if (fDebug)
-                //    printf("Sending bucket %"PRId64", size %d \n", it->first, it->second.size());
+                //    printf("Sending bucket %" PRId64 ", size %d \n", it->first, it->second.size());
             };
             
             if (vchData.size() > 4)
@@ -2137,7 +2137,7 @@ bool ScanChainForPublicKeys(CBlockIndex* pindexStart)
     
     printf("Scanned %u blocks, %u transactions, %u inputs\n", nBlocks, nTransactions, nInputs);
     printf("Found %u public keys, %u duplicates.\n", nPubkeys, nDuplicates);
-    printf("Took %"PRId64" ms\n", GetTimeMillis() - nStart);
+    printf("Took %" PRId64 " ms\n", GetTimeMillis() - nStart);
     
     return true;
 };
@@ -2316,7 +2316,7 @@ bool SecureMsgScanBuckets()
     };
     
     printf("Processed %u files, scanned %u messages, received %u messages.\n", nFiles, nMessages, nFoundMessages);
-    printf("Took %"PRId64" ms\n", GetTimeMillis() - mStart);
+    printf("Took %" PRId64 " ms\n", GetTimeMillis() - mStart);
     
     return true;
 }
@@ -2763,18 +2763,18 @@ int SecureMsgAddAddress(std::string& address, std::string& publicKey)
 int SecureMsgRetrieve(SecMsgToken &token, std::vector<unsigned char>& vchData)
 {
     if (fDebug)
-        printf("SecureMsgRetrieve() %"PRId64".\n", token.timestamp);
+        printf("SecureMsgRetrieve() %" PRId64 ".\n", token.timestamp);
     
     // -- has cs_smsg lock from SecureMsgReceiveData
     
     fs::path pathSmsgDir = GetDataDir() / "smsgStore";
     
-    //printf("token.offset %"PRId64".\n", token.offset); // DEBUG
+    //printf("token.offset %" PRId64 ".\n", token.offset); // DEBUG
     int64_t bucket = token.timestamp - (token.timestamp % SMSG_BUCKET_LEN);
     std::string fileName = boost::lexical_cast<std::string>(bucket) + "_01.dat";
     fs::path fullpath = pathSmsgDir / fileName;
     
-    //printf("bucket %"PRId64".\n", bucket);
+    //printf("bucket %" PRId64 ".\n", bucket);
     //printf("bucket lld %lld.\n", bucket);
     //printf("fileName %s.\n", fileName.c_str());
     
@@ -2865,7 +2865,7 @@ int SecureMsgReceive(CNode* pfrom, std::vector<unsigned char>& vchData)
     
     if (nBunch == 0 || nBunch > 500)
     {
-        printf("Error: Invalid no. messages received in bunch %u, for bucket %"PRId64".\n", nBunch, bktTime);
+        printf("Error: Invalid no. messages received in bunch %u, for bucket %" PRId64 ".\n", nBunch, bktTime);
         pfrom->Misbehaving(1);
         
         // -- release lock on bucket if it exists
@@ -2921,7 +2921,7 @@ int SecureMsgReceive(CNode* pfrom, std::vector<unsigned char>& vchData)
     if (itb == smsgBuckets.end())
     {
         if (fDebug)
-            printf("Don't have bucket %"PRId64".\n", bktTime);
+            printf("Don't have bucket %" PRId64 ".\n", bktTime);
         return 1;
     };
     
@@ -3054,9 +3054,9 @@ int SecureMsgStore(unsigned char *pHeader, unsigned char *pPayload, uint32_t nPa
             if (fDebug)
             {
                 printf("nPayload: %u\n", nPayload);
-                printf("bucket: %"PRId64"\n", bucket);
+                printf("bucket: %" PRId64 "\n", bucket);
                 
-                printf("message ts: %"PRId64, token.timestamp);
+                printf("message ts: %" PRId64, token.timestamp);
                 std::vector<unsigned char> vchShow;
                 vchShow.resize(8);
                 memcpy(&vchShow[0], token.sample, 8);
@@ -3109,7 +3109,7 @@ int SecureMsgStore(unsigned char *pHeader, unsigned char *pPayload, uint32_t nPa
         
         token.offset = ofs;
         
-        //printf("token.offset: %"PRId64"\n", token.offset); // DEBUG
+        //printf("token.offset: %" PRId64 "\n", token.offset); // DEBUG
         tokenSet.insert(token);
         
         if (fUpdateBucket)
@@ -3117,7 +3117,7 @@ int SecureMsgStore(unsigned char *pHeader, unsigned char *pPayload, uint32_t nPa
     };
     
     //if (fDebug)
-    printf("SecureMsg added to bucket %"PRId64".\n", bucket);
+    printf("SecureMsg added to bucket %" PRId64 ".\n", bucket);
     return 0;
 };
 
@@ -3292,7 +3292,7 @@ int SecureMsgSetHash(unsigned char *pHeader, unsigned char *pPayload, uint32_t n
     if (!found)
     {
         if (fDebug)
-            printf("SecureMsgSetHash() failed, took %"PRId64" ms, nonse %u\n", GetTimeMillis() - nStart, nonse);
+            printf("SecureMsgSetHash() failed, took %" PRId64 " ms, nonse %u\n", GetTimeMillis() - nStart, nonse);
         return 1;
     };
     
@@ -3300,7 +3300,7 @@ int SecureMsgSetHash(unsigned char *pHeader, unsigned char *pPayload, uint32_t n
     //memcpy(psmsg->hash, &vchHash[0], 4);
     
     if (fDebug)
-        printf("SecureMsgSetHash() took %"PRId64" ms, nonse %u\n", GetTimeMillis() - nStart, nonse);
+        printf("SecureMsgSetHash() took %" PRId64 " ms, nonse %u\n", GetTimeMillis() - nStart, nonse);
     
     return 0;
 };
@@ -3336,7 +3336,7 @@ int SecureMsgEncrypt(SecureMessage& smsg, std::string& addressFrom, std::string&
     
     if (message.size() > SMSG_MAX_MSG_BYTES)
     {
-        printf("Message is too long, %"PRIszu".\n", message.size());
+        printf("Message is too long, %" PRIszu ".\n", message.size());
         return 2;
     };
     
@@ -3603,7 +3603,7 @@ int SecureMsgSend(std::string& addressFrom, std::string& addressTo, std::string&
         std::ostringstream oss;
         oss << message.size() << " > " << SMSG_MAX_MSG_BYTES;
         sError = "Message is too long, " + oss.str();
-        printf("Message is too long, %"PRIszu".\n", message.size());
+        printf("Message is too long, %" PRIszu ".\n", message.size());
         return 1;
     };
     

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -118,8 +118,6 @@ bool CWallet::Unlock(const SecureString& strWalletPassphrase)
 
 bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase, const SecureString& strNewWalletPassphrase)
 {
-    bool fWasLocked = IsLocked();
-
     {
         LOCK(cs_wallet);
 
@@ -1565,7 +1563,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CW
                 int nIn = 0;
                 BOOST_FOREACH(const PAIRTYPE(const CWalletTx*,unsigned int)& coin, setCoins)
                     if (!SignSignature(*this, *coin.first, wtxNew, nIn++)) {
-			printf("CreateTransaction() : Sign Signatue Failed \n");
+			printf("CreateTransaction() : Sign Signature Failed \n");
                         return false;
 		    }
 
@@ -2077,9 +2075,9 @@ bool CWallet::SendStealthMoneyToDestination(CStealthAddress& sxAddress, int64_t 
     
     if (fDebug)
     {
-        printf("Stealth send to generated pubkey %"PRIszu": %s\n", pkSendTo.size(), HexStr(pkSendTo).c_str());
+        printf("Stealth send to generated pubkey %" PRIszu ": %s\n", pkSendTo.size(), HexStr(pkSendTo).c_str());
         printf("hash %s\n", addrTo.ToString().c_str());
-        printf("ephem_pubkey %"PRIszu": %s\n", ephem_pubkey.size(), HexStr(ephem_pubkey).c_str());
+        printf("ephem_pubkey %" PRIszu ": %s\n", ephem_pubkey.size(), HexStr(ephem_pubkey).c_str());
     };
     
     std::vector<unsigned char> vchNarr;
@@ -2210,7 +2208,7 @@ bool CWallet::FindStealthTransactions(const CTransaction& tx, mapValue_t& mapNar
                     printf("StealthSecret failed.\n");
                     continue;
                 };
-                //printf("pkExtracted %"PRIszu": %s\n", pkExtracted.size(), HexStr(pkExtracted).c_str());
+                //printf("pkExtracted %" PRIszu ": %s\n", pkExtracted.size(), HexStr(pkExtracted).c_str());
                 
                 CPubKey cpkE(pkExtracted);
                 


### PR DESCRIPTION
In this PR:

- Properly link Boost so it's a 1-click install. Closes #46, #148, #150, #166, #182, #183, #198, #228 
- Remove macports configuration. We don't use that anymore
- Update OS X build instructions
- Update OS X usage. You no longer need to install boost 😄 
- Update to using c++11 on OS X
- Fix a bunch of c++11 warnings
- Ignore release `.zip` files so they're not checked into source control

This also resolves #281. New logo is in.