### PR TITLE
update linux build instruction, make clean

### DIFF
--- a/building/linux/build.sh
+++ b/building/linux/build.sh
@@ -1,3 +1,4 @@
 ./autogen.sh
 ./configure --with-gui=qt5
+make clean
 make

--- a/doc/build-verge-linux.md
+++ b/doc/build-verge-linux.md
@@ -17,7 +17,7 @@ The _slightly_ longer version:
     sudo apt-get install \
         libdb4.8-dev libdb4.8++-dev build-essential \
         libtool autotools-dev automake pkg-config libssl-dev zlib1g-dev libz-dev libevent-dev \
-        bsdmainutils git libboost-all-dev libseccomp-dev libncap-dev libminiupnpc-dev libqt5gui5 \
+        bsdmainutils git libboost-all-dev libseccomp-dev libcap-dev libminiupnpc-dev libqt5gui5 \
         libqt5core5a libqt5webkit5-dev libqt5dbus5 qttools5-dev \
         qttools5-dev-tools libprotobuf-dev protobuf-compiler libqrencode-dev
     ```


### PR DESCRIPTION
Updating linux build doc  https://github.com/vergecurrency/VERGE/blob/master/building/linux/requirements.sh#L9
(seems we need libcap-dev)

Also, adding make clean before make just so any previous remains are cleaned up.

