### PR TITLE
#318 Adding a loading indicator for showing current load procedure 

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -667,7 +667,7 @@ bool AppInit2()
     uiInterface.InitMessage(_("Loading block index..."));
     printf("Loading block index...\n");
     nStart = GetTimeMillis();
-    if (!LoadBlockIndex())
+    if (!LoadBlockIndex(true, (&uiInterface)))
         return InitError(_("Error loading blkindex.dat"));
 
     // as LoadBlockIndex can take several minutes, it's possible the user

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2818,7 +2818,7 @@ FILE* AppendBlockFile(unsigned int& nFileRet)
     return NULL;
 }
 
-bool LoadBlockIndex(bool fAllowNew)
+bool LoadBlockIndex(bool fAllowNew,CClientUIInterface* uiInterface)
 {
     if (fTestNet)
     {
@@ -2839,7 +2839,7 @@ bool LoadBlockIndex(bool fAllowNew)
     // Load block index
     //
     CTxDB txdb("cr");
-    if (!txdb.LoadBlockIndex())
+    if (!txdb.LoadBlockIndex(uiInterface))
         return false;
 
     //
@@ -2851,12 +2851,12 @@ bool LoadBlockIndex(bool fAllowNew)
             return false;
 
         // Genesis Block:
-//CBlock(hash=0000068e0b99f3db472b, ver=1, hashPrevBlock=00000000000000000000,
-// hashMerkleRoot=ea6fed5e25, nTime=1368496587, nBits=1e0fffff, nNonce=578618, vtx=1, vchBlockSig=)
-//  Coinbase(hash=ea6fed5e25, nTime=1368496567, ver=1, vin.size=1, vout.size=1, nLockTime=0)
-//    CTxIn(COutPoint(0000000000, 4294967295), coinbase 04ffff001d020f2706787878787878)
-//    CTxOut(empty)
-//vMerkleTree: ea6fed5e2
+        //CBlock(hash=0000068e0b99f3db472b, ver=1, hashPrevBlock=00000000000000000000,
+        // hashMerkleRoot=ea6fed5e25, nTime=1368496587, nBits=1e0fffff, nNonce=578618, vtx=1, vchBlockSig=)
+        //  Coinbase(hash=ea6fed5e25, nTime=1368496567, ver=1, vin.size=1, vout.size=1, nLockTime=0)
+        //    CTxIn(COutPoint(0000000000, 4294967295), coinbase 04ffff001d020f2706787878787878)
+        //    CTxOut(empty)
+        //vMerkleTree: ea6fed5e2
         // Genesis block
         const char* pszTimestamp = "Name: Dogecoin Dark";
 				if(fTestNet)

--- a/src/main.h
+++ b/src/main.h
@@ -15,6 +15,7 @@
 #include "hashx17.h"
 #include "Lyra2RE.h"
 #include <list>
+#include "ui_interface.h"
 
 class CWallet;
 class CBlock;
@@ -104,7 +105,7 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock);
 bool CheckDiskSpace(uint64 nAdditionalBytes=0);
 FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszMode="rb");
 FILE* AppendBlockFile(unsigned int& nFileRet);
-bool LoadBlockIndex(bool fAllowNew=true);
+bool LoadBlockIndex(bool fAllowNew=true, CClientUIInterface* uiInterface=NULL);
 void PrintBlockTree();
 CBlockIndex* FindBlockByHeight(int nHeight);
 bool ProcessMessages(CNode* pfrom);

--- a/src/txdb-leveldb.h
+++ b/src/txdb-leveldb.h
@@ -14,6 +14,7 @@
 
 #include <leveldb/db.h>
 #include <leveldb/write_batch.h>
+#include "ui_interface.h"
 
 // Class that provides access to a LevelDB. Note that this class is frequently
 // instantiated on the stack and then destroyed again, so instantiation has to
@@ -201,7 +202,7 @@ public:
     bool WriteSyncCheckpoint(uint256 hashCheckpoint);
     bool ReadCheckpointPubKey(std::string& strPubKey);
     bool WriteCheckpointPubKey(const std::string& strPubKey);
-    bool LoadBlockIndex();
+    bool LoadBlockIndex(CClientUIInterface* uiInterface=NULL);
 private:
     bool LoadBlockIndexGuts();
 };

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1926,14 +1926,6 @@ bool CWallet::UpdateStealthAddress(std::string &addr, std::string &label, bool a
             // no change
             return true;
         };
-        
-        it->label = label; // update in .stealthAddresses
-        
-        if (sxFound.scan_secret.size() == ec_secret_size)
-        {
-            printf("UpdateStealthAddress: todo - update owned stealth address.\n");
-            return false;
-        };
     };
     
     sxFound.label = label;

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1926,6 +1926,14 @@ bool CWallet::UpdateStealthAddress(std::string &addr, std::string &label, bool a
             // no change
             return true;
         };
+        
+        it->label = label; // update in .stealthAddresses
+        
+        if (sxFound.scan_secret.size() == ec_secret_size)
+        {
+            printf("UpdateStealthAddress: todo - update owned stealth address.\n");
+            return false;
+        };
     };
     
     sxFound.label = label;


### PR DESCRIPTION
Solves #318 - Adding a loading indicator for showing current load procedure 

## Related Issue
#318 WP: Add progress indicator on splash screen while loading blockchain

## How Has This Been Tested?
Has been test on MacOS High Sierra (PRO), no performance issue.
Clearly lightweight percentage indicator on splash screen.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/7430964/34882995-82cf164e-f7b8-11e7-9eee-5c7764ecf35b.png)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
