### PR TITLE
Fixes a bug where you aren't able to relabel stealth addresses

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1926,14 +1926,6 @@ bool CWallet::UpdateStealthAddress(std::string &addr, std::string &label, bool a
             // no change
             return true;
         };
-        
-        it->label = label; // update in .stealthAddresses
-        
-        if (sxFound.scan_secret.size() == ec_secret_size)
-        {
-            printf("UpdateStealthAddress: todo - update owned stealth address.\n");
-            return false;
-        };
     };
     
     sxFound.label = label;


### PR DESCRIPTION
## Related Issue
Cannot rename address label #437 
Cannot edit the label of stealth address on MacOS #447 

## How Has This Been Tested?
tested on macOS High Sierra

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
