### PR TITLE
(fix): Added libevent brew installation for mac building of requirements

### DIFF
--- a/building/mac/requirements.sh
+++ b/building/mac/requirements.sh
@@ -5,7 +5,7 @@ brew uninstall qt5
 brew install boost@1.60 pkg-config automake
 
 # Install some deps
-brew install qt@5.5 protobuf miniupnpc openssl qrencode berkeley-db4 zlib
+brew install qt@5.5 protobuf miniupnpc openssl qrencode berkeley-db4 zlib libevent
 
 # Make sure our stuff is linked in our path
 brew link automake autoconf


### PR DESCRIPTION
Fixed requirements.sh to explicitly brew install libevent

## Description
Added brew install libevent

## Related Issue
https://github.com/vergecurrency/VERGE/issues/471

## Motivation and Context
Make it easier to build mac locally.

## How Has This Been Tested?
Tested it locally and it worked.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
