### PR TITLE
Feature automatic transfer amount selection

### DIFF
--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -1,169 +1,216 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>SendCoinsEntry</class>
- <widget class="QFrame" name="SendCoinsEntry">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>729</width>
-    <height>136</height>
-   </rect>
-  </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
-  <property name="frameShape">
-   <enum>QFrame::StyledPanel</enum>
-  </property>
-  <property name="frameShadow">
-   <enum>QFrame::Sunken</enum>
-  </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <property name="spacing">
-    <number>12</number>
-   </property>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>A&amp;mount:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="buddy">
-      <cstring>payAmount</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Pay &amp;To:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="buddy">
-      <cstring>payTo</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="BitcoinAmountField" name="payAmount"/>
-   </item>
-   <item row="4" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QValidatedLineEdit" name="addAsLabel">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="toolTip">
-        <string>Enter a label for this address to add it to your address book</string>
-       </property>
-      </widget>
-     </item>
+  <class>SendCoinsEntry</class>
+  <widget class="QFrame" name="SendCoinsEntry">
+    <property name="geometry">
+      <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>729</width>
+        <height>136</height>
+      </rect>
+    </property>
+    <property name="windowTitle">
+      <string>Form</string>
+    </property>
+    <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+    </property>
+    <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+    </property>
+    <layout class="QGridLayout" name="gridLayout">
+      <property name="spacing">
+        <number>12</number>
+      </property>
+      <item row="5" column="0">
+        <widget class="QLabel" name="label">
+          <property name="text">
+            <string>A&amp;mount:</string>
+          </property>
+          <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="buddy">
+            <cstring>payAmount</cstring>
+          </property>
+        </widget>
+      </item>
+      <item row="5" column="1">
+        <layout class="QGridLayout" name="gridLayoutAmount">
+          <property name="spacing">
+            <number>12</number>
+          </property>
+          <item row="0" column="0">
+            <widget class="BitcoinAmountField" name="payAmount"/>
+          </item>
+          <item row="0" column="1">
+          <layout class="QHBoxLayout" name="setAmountLimits">
+              <property name="spacing">
+                <number>0</number>
+              </property>
+              <item>
+                <widget class="QToolButton" name="quarteramount">
+                  <property name="toolTip">
+                    <string>Sets the value to 25% of you current wallet amount.</string>
+                  </property>
+                  <property name="text">
+                    <string>25%</string>
+                  </property>
+                </widget>
+              </item>
+              <item>
+                <widget class="QToolButton" name="halfamount">
+                  <property name="toolTip">
+                    <string>Sets the value to 50% of you current wallet amount.</string>
+                  </property>
+                  <property name="text">
+                    <string>50%</string>
+                  </property>
+                </widget>
+              </item>
+              <item>
+                <widget class="QToolButton" name="fullamount">
+                  <property name="toolTip">
+                    <string>Sets the value to 100% of you current wallet amount.</string>
+                  </property>
+                  <property name="text">
+                    <string>100%</string>
+                  </property>
+                </widget>
+              </item>
+            </layout>
+          </item>
+        </layout>
+      </item>
+      <item row="3" column="0">
+        <widget class="QLabel" name="label_2">
+          <property name="text">
+            <string>Pay &amp;To:</string>
+          </property>
+          <property name="alignment">
+            <set>Qt::AlignLeft|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="buddy">
+            <cstring>payTo</cstring>
+          </property>
+        </widget>
+      </item>
+      <item row="4" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <property name="spacing">
+            <number>0</number>
+          </property>
+          <item>
+            <widget class="QValidatedLineEdit" name="addAsLabel">
+              <property name="enabled">
+                <bool>true</bool>
+              </property>
+              <property name="toolTip">
+                <string>Enter a label for this address to add it to your address book</string>
+              </property>
+            </widget>
+          </item>
+        </layout>
+      </item>
+      <item row="4" column="0">
+        <widget class="QLabel" name="label_4">
+          <property name="text">
+            <string>&amp;Label:</string>
+          </property>
+          <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="buddy">
+            <cstring>addAsLabel</cstring>
+          </property>
+        </widget>
+      </item>
+      <item row="3" column="1">
+        <layout class="QHBoxLayout" name="payToLayout">
+          <property name="spacing">
+            <number>0</number>
+          </property>
+          <item>
+            <widget class="QValidatedLineEdit" name="payTo">
+              <property name="toolTip">
+                <string>The address to send the payment to  (e.g. DDd1pVWr8PPAw1z7DRwoUW6maWh5SsnCcp)</string>
+              </property>
+              <property name="maxLength">
+                <number>102</number>
+              </property>
+            </widget>
+          </item>
+          <item>
+            <widget class="QToolButton" name="addressBookButton">
+              <property name="toolTip">
+                <string>Choose address from address book</string>
+              </property>
+              <property name="text">
+                <string/>
+              </property>
+              <property name="icon">
+                <iconset resource="../bitcoin.qrc">
+                  <normaloff>:/icons/address-book_filled</normaloff>:/icons/address-book_filled                                                                                                                            
+                </iconset>
+              </property>
+              <property name="shortcut">
+                <string>Alt+A</string>
+              </property>
+            </widget>
+          </item>
+          <item>
+            <widget class="QToolButton" name="pasteButton">
+              <property name="toolTip">
+                <string>Paste address from clipboard</string>
+              </property>
+              <property name="text">
+                <string/>
+              </property>
+              <property name="icon">
+                <iconset resource="../bitcoin.qrc">
+                  <normaloff>:/icons/editpaste</normaloff>:/icons/editpaste                                                                                                                            
+                </iconset>
+              </property>
+              <property name="shortcut">
+                <string>Alt+P</string>
+              </property>
+            </widget>
+          </item>
+          <item>
+            <widget class="QToolButton" name="deleteButton">
+              <property name="toolTip">
+                <string>Remove this recipient</string>
+              </property>
+              <property name="text">
+                <string/>
+              </property>
+              <property name="icon">
+                <iconset resource="../bitcoin.qrc">
+                  <normaloff>:/icons/remove</normaloff>:/icons/remove                                                                                                                            
+                </iconset>
+              </property>
+            </widget>
+          </item>
+        </layout>
+      </item>
     </layout>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>&amp;Label:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="buddy">
-      <cstring>addAsLabel</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <layout class="QHBoxLayout" name="payToLayout">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QValidatedLineEdit" name="payTo">
-       <property name="toolTip">
-        <string>The address to send the payment to  (e.g. DDd1pVWr8PPAw1z7DRwoUW6maWh5SsnCcp)</string>
-       </property>
-       <property name="maxLength">
-        <number>102</number>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="addressBookButton">
-       <property name="toolTip">
-        <string>Choose address from address book</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="../bitcoin.qrc">
-         <normaloff>:/icons/address-book_filled</normaloff>:/icons/address-book_filled</iconset>
-       </property>
-       <property name="shortcut">
-        <string>Alt+A</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="pasteButton">
-       <property name="toolTip">
-        <string>Paste address from clipboard</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="../bitcoin.qrc">
-         <normaloff>:/icons/editpaste</normaloff>:/icons/editpaste</iconset>
-       </property>
-       <property name="shortcut">
-        <string>Alt+P</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="deleteButton">
-       <property name="toolTip">
-        <string>Remove this recipient</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="../bitcoin.qrc">
-         <normaloff>:/icons/remove</normaloff>:/icons/remove</iconset>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-  </layout>
- </widget>
- <customwidgets>
-  <customwidget>
-   <class>BitcoinAmountField</class>
-   <extends>QSpinBox</extends>
-   <header>bitcoinamountfield.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QValidatedLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qvalidatedlineedit.h</header>
-  </customwidget>
- </customwidgets>
- <resources>
-  <include location="../bitcoin.qrc"/>
- </resources>
- <connections/>
+  </widget>
+  <customwidgets>
+    <customwidget>
+      <class>BitcoinAmountField</class>
+      <extends>QSpinBox</extends>
+      <header>bitcoinamountfield.h</header>
+      <container>1</container>
+    </customwidget>
+    <customwidget>
+      <class>QValidatedLineEdit</class>
+      <extends>QLineEdit</extends>
+      <header>qvalidatedlineedit.h</header>
+    </customwidget>
+  </customwidgets>
+  <resources>
+    <include location="../bitcoin.qrc"/>
+  </resources>
+  <connections/>
 </ui>

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -44,6 +44,27 @@ void SendCoinsEntry::on_pasteButton_clicked()
     ui->payTo->setText(QApplication::clipboard()->text());
 }
 
+void SendCoinsEntry::on_fullamount_clicked(){
+    if(!model)
+        return;
+
+    ui->payAmount->setValue(model->getAvailableAmount(1));
+}
+
+void SendCoinsEntry::on_halfamount_clicked(){
+    if(!model)
+        return;
+    
+    ui->payAmount->setValue(model->getAvailableAmount(2));
+}
+
+void SendCoinsEntry::on_quarteramount_clicked(){
+    if(!model)
+        return;
+    
+    ui->payAmount->setValue(model->getAvailableAmount(4));
+}
+
 void SendCoinsEntry::on_addressBookButton_clicked()
 {
     if(!model)
@@ -134,7 +155,7 @@ SendCoinsRecipient SendCoinsEntry::getValue()
     rv.label = ui->addAsLabel->text();
     rv.amount = ui->payAmount->value();
 
- if (rv.address.length() > 75 
+    if (rv.address.length() > 75 
         && IsStealthAddress(rv.address.toStdString()))
         rv.typeInd = AddressTableModel::AT_Stealth;
     else

--- a/src/qt/sendcoinsentry.h
+++ b/src/qt/sendcoinsentry.h
@@ -44,6 +44,9 @@ private slots:
     void on_deleteButton_clicked();
     void on_payTo_textChanged(const QString &address);
     void on_addressBookButton_clicked();
+    void on_fullamount_clicked();
+    void on_halfamount_clicked();
+    void on_quarteramount_clicked();
     void on_pasteButton_clicked();
     void updateDisplayUnit();
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -9,11 +9,12 @@
 #include "walletdb.h" // for BackupWallet
 #include "base58.h"
 #include "smessage.h"
+#include "util.h"
 
 #include <QSet>
 #include <QTimer>
 
-WalletModel::WalletModel(CWallet *wallet, OptionsModel *optionsModel, QObject *parent) :
+WalletModel::WalletModel(CWallet *wallet, OptionsModel *optionsModel, QObject *parent) : 
     QObject(parent), wallet(wallet), optionsModel(optionsModel), addressTableModel(0),
     transactionTableModel(0),
     cachedBalance(0), cachedUnconfirmedBalance(0), cachedImmatureBalance(0),
@@ -50,6 +51,23 @@ qint64 WalletModel::getUnconfirmedBalance() const
 qint64 WalletModel::getImmatureBalance() const
 {
     return wallet->GetImmatureBalance();
+}
+
+qint64 WalletModel::getAvailableAmount(int parts) const
+{
+    qint64 balance = getBalance();
+    if(parts <= 0 || !MoneyRange(balance)){
+        return 0;
+    }
+
+    qint64 transaction_amount = (balance / parts) - nTransactionFee;
+
+    if(parts <= 0 || !MoneyRange(transaction_amount)){
+        std::cout << "Out of range error after calculation" << std::endl;
+        return 0;
+    }
+
+    return transaction_amount;
 }
 
 int WalletModel::getNumTransactions() const

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -69,6 +69,7 @@ public:
     qint64 getBalance() const;
     qint64 getUnconfirmedBalance() const;
     qint64 getImmatureBalance() const;
+    qint64 getAvailableAmount(int parts) const;
     int getNumTransactions() const;
     EncryptionStatus getEncryptionStatus() const;
 


### PR DESCRIPTION
Adds the option to set 25%, 50% or 100% of your current balance as your transaction balance.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#406 Enhancement Request Template

## How Has This Been Tested?
Must be tested with certain balances.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/7430964/35017081-92252faa-fb1b-11e7-9d24-cccc1a354584.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.

