### PR TITLE
Fix wallet lock problem

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -72,6 +72,7 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     walletModel(0),
     encryptWalletAction(0),
     unlockWalletAction(0),
+    lockWalletAction(0),
     changePassphraseAction(0),
     aboutQtAction(0),
     trayIcon(0),
@@ -276,6 +277,7 @@ void BitcoinGUI::createActions()
     encryptWalletAction->setToolTip(tr("Encrypt or decrypt wallet"));
     encryptWalletAction->setCheckable(true);
     unlockWalletAction = new QAction(QIcon(":/icons/lock_open"), tr("&Unlock Wallet..."), this);
+    lockWalletAction = new QAction(QIcon(":/icons/lock_closed"), tr("&Lock  Wallet..."), this);
     backupWalletAction = new QAction(QIcon(":/icons/filesave"), tr("&Backup Wallet..."), this);
     backupWalletAction->setToolTip(tr("Backup wallet to another location"));
     changePassphraseAction = new QAction(QIcon(":/icons/key"), tr("&Change Passphrase..."), this);
@@ -292,6 +294,7 @@ void BitcoinGUI::createActions()
     connect(backupWalletAction, SIGNAL(triggered()), this, SLOT(backupWallet()));
     connect(changePassphraseAction, SIGNAL(triggered()), this, SLOT(changePassphrase()));
     connect(unlockWalletAction, SIGNAL(triggered()), this, SLOT(unlockWalletForMinting()));
+    connect(lockWalletAction, SIGNAL(triggered()), this, SLOT(unlockWalletForMinting()));
     connect(signMessageAction, SIGNAL(triggered()), this, SLOT(gotoSignMessageTab()));
     connect(verifyMessageAction, SIGNAL(triggered()), this, SLOT(gotoVerifyMessageTab()));
 }
@@ -320,6 +323,8 @@ void BitcoinGUI::createMenuBar()
     settings->addAction(changePassphraseAction);
     settings->addSeparator();
     settings->addAction(unlockWalletAction);
+    settings->addSeparator();
+    settings->addAction(lockWalletAction);
     settings->addSeparator();
     settings->addAction(optionsAction);
 
@@ -455,6 +460,7 @@ void BitcoinGUI::createTrayIcon()
     trayIconMenu->addSeparator();
     trayIconMenu->addAction(encryptWalletAction);
     trayIconMenu->addAction(unlockWalletAction);
+    trayIconMenu->addAction(lockWalletAction);
     trayIconMenu->addAction(changePassphraseAction);
     trayIconMenu->addSeparator();
     trayIconMenu->addAction(optionsAction);
@@ -832,6 +838,7 @@ void BitcoinGUI::setEncryptionStatus(int status)
         encryptWalletAction->setChecked(false);
         changePassphraseAction->setEnabled(false);
         unlockWalletAction->setEnabled(false);
+        lockWalletAction->setEnabled(false);
         encryptWalletAction->setEnabled(true);
         break;
     case WalletModel::Unlocked:
@@ -841,6 +848,7 @@ void BitcoinGUI::setEncryptionStatus(int status)
         encryptWalletAction->setChecked(true);
         changePassphraseAction->setEnabled(true);
         unlockWalletAction->setEnabled(false);
+        lockWalletAction->setEnabled(true);
         encryptWalletAction->setEnabled(false); // TODO: decrypt currently not supported
         break;
     case WalletModel::Locked:
@@ -849,6 +857,7 @@ void BitcoinGUI::setEncryptionStatus(int status)
         labelEncryptionIcon->setToolTip(tr("Wallet is <b>encrypted</b> and currently <b>locked</b>"));
         encryptWalletAction->setChecked(true);
         unlockWalletAction->setEnabled(true);
+        lockWalletAction->setEnabled(false);
         changePassphraseAction->setEnabled(true);
         encryptWalletAction->setEnabled(false); // TODO: decrypt currently not supported
         break;

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -91,6 +91,7 @@ private:
     QAction *exportAction;
     QAction *encryptWalletAction;
     QAction *unlockWalletAction;
+    QAction *lockWalletAction;
     QAction *backupWalletAction;
     QAction *changePassphraseAction;
     QAction *aboutQtAction;

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1498,7 +1498,7 @@ Value walletlock(const Array& params, bool fHelp)
 
     {
         LOCK(cs_nWalletUnlockTime);
-        //pwalletMain->Lock();
+        pwalletMain->Lock();
         nWalletUnlockTime = 0;
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix walletlock command and adds possbility of locking in menubar/traysettings.

Fixes #497 

## How Has This Been Tested?
Ubuntu 16.04 with testnet

For some reason pwalletMain->Lock(); was commented out in the walletLock function in commit 1a171d93551455d839867f714ebacff4a07dacbd

The names of the unlockWallet/unlockWalletForMinting that call setWalletLock() are bit confusing as setWalletLock will just flip the lock depending on its state. So I added a lockWalletAction which currently uses the same function as unlockWalletAction. Thought id upload the initial fix and then a discussion about the naming could be had perhaps?

## Screenshots (if appropriate):

![walletlock](https://user-images.githubusercontent.com/11488530/35038366-e7c2508c-fb7a-11e7-91e6-561be76fd529.png)

![lock2](https://user-images.githubusercontent.com/11488530/35038373-ee934236-fb7a-11e7-9e66-93b6d076f7f1.png)

![lockadded](https://user-images.githubusercontent.com/11488530/35038374-f1297402-fb7a-11e7-99e9-902cad2ddc7a.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
