### PR TITLE
Feature automatic transfer amount selection (fixed)

### DIFF
--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -131,6 +131,11 @@ void BitcoinAmountField::setValue(qint64 value)
     setText(BitcoinUnits::format(currentUnit, value));
 }
 
+void BitcoinAmountField::setValueWithoutComma(qint64 value)
+{
+    setText(BitcoinUnits::format(currentUnit, value, false, true));
+}
+
 void BitcoinAmountField::unitChanged(int idx)
 {
     // Use description tooltip for current unit for the combobox

--- a/src/qt/bitcoinamountfield.h
+++ b/src/qt/bitcoinamountfield.h
@@ -19,6 +19,7 @@ public:
 
     qint64 value(bool *valid=0) const;
     void setValue(qint64 value);
+    void setValueWithoutComma(qint64 value);
 
     /** Mark current value as invalid in UI. */
     void setValid(bool valid);

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -85,7 +85,7 @@ int BitcoinUnits::decimals(int unit)
     }
 }
 
-QString BitcoinUnits::format(int unit, qint64 n, bool fPlus)
+QString BitcoinUnits::format(int unit, qint64 n, bool fPlus, bool fnoComma)
 {
     // Note: not using straight sprintf here because we do NOT want
     // localized number formatting.
@@ -96,8 +96,14 @@ QString BitcoinUnits::format(int unit, qint64 n, bool fPlus)
     qint64 n_abs = (n > 0 ? n : -n);
     qint64 quotient = n_abs / coin;
     qint64 remainder = n_abs % coin;
-    //QString quotient_str = QString::number(quotient);
-    QString quotient_str = QLocale(QLocale::English).toString(quotient);
+    QString quotient_str;
+
+    if (fnoComma)
+        quotient_str = QString::number(quotient);
+    else
+        quotient_str = QLocale(QLocale::English).toString(quotient);
+
+
     QString remainder_str = QString::number(remainder).rightJustified(num_decimals, '0');
 
     // Right-trim excess zeros after the decimal point

--- a/src/qt/bitcoinunits.h
+++ b/src/qt/bitcoinunits.h
@@ -42,7 +42,7 @@ public:
     //! Number of decimals left
     static int decimals(int unit);
     //! Format as string
-    static QString format(int unit, qint64 amount, bool plussign=false);
+    static QString format(int unit, qint64 amount, bool plussign=false, bool noComma=false);
     //! Format as string (with unit)
     static QString formatWithUnit(int unit, qint64 amount, bool plussign=false);
     //! Parse string to coin amount

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -1,169 +1,216 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>SendCoinsEntry</class>
- <widget class="QFrame" name="SendCoinsEntry">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>729</width>
-    <height>136</height>
-   </rect>
-  </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
-  <property name="frameShape">
-   <enum>QFrame::StyledPanel</enum>
-  </property>
-  <property name="frameShadow">
-   <enum>QFrame::Sunken</enum>
-  </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <property name="spacing">
-    <number>12</number>
-   </property>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>A&amp;mount:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="buddy">
-      <cstring>payAmount</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Pay &amp;To:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="buddy">
-      <cstring>payTo</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="BitcoinAmountField" name="payAmount"/>
-   </item>
-   <item row="4" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QValidatedLineEdit" name="addAsLabel">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="toolTip">
-        <string>Enter a label for this address to add it to your address book</string>
-       </property>
-      </widget>
-     </item>
+  <class>SendCoinsEntry</class>
+  <widget class="QFrame" name="SendCoinsEntry">
+    <property name="geometry">
+      <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>729</width>
+        <height>136</height>
+      </rect>
+    </property>
+    <property name="windowTitle">
+      <string>Form</string>
+    </property>
+    <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+    </property>
+    <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+    </property>
+    <layout class="QGridLayout" name="gridLayout">
+      <property name="spacing">
+        <number>12</number>
+      </property>
+      <item row="5" column="0">
+        <widget class="QLabel" name="label">
+          <property name="text">
+            <string>A&amp;mount:</string>
+          </property>
+          <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="buddy">
+            <cstring>payAmount</cstring>
+          </property>
+        </widget>
+      </item>
+      <item row="5" column="1">
+        <layout class="QGridLayout" name="gridLayoutAmount">
+          <property name="spacing">
+            <number>12</number>
+          </property>
+          <item row="0" column="0">
+            <widget class="BitcoinAmountField" name="payAmount"/>
+          </item>
+          <item row="0" column="1">
+          <layout class="QHBoxLayout" name="setAmountLimits">
+              <property name="spacing">
+                <number>0</number>
+              </property>
+              <item>
+                <widget class="QToolButton" name="quarteramount">
+                  <property name="toolTip">
+                    <string>Sets the value to 25% of you current wallet amount.</string>
+                  </property>
+                  <property name="text">
+                    <string>25%</string>
+                  </property>
+                </widget>
+              </item>
+              <item>
+                <widget class="QToolButton" name="halfamount">
+                  <property name="toolTip">
+                    <string>Sets the value to 50% of you current wallet amount.</string>
+                  </property>
+                  <property name="text">
+                    <string>50%</string>
+                  </property>
+                </widget>
+              </item>
+              <item>
+                <widget class="QToolButton" name="fullamount">
+                  <property name="toolTip">
+                    <string>Sets the value to 100% of you current wallet amount.</string>
+                  </property>
+                  <property name="text">
+                    <string>100%</string>
+                  </property>
+                </widget>
+              </item>
+            </layout>
+          </item>
+        </layout>
+      </item>
+      <item row="3" column="0">
+        <widget class="QLabel" name="label_2">
+          <property name="text">
+            <string>Pay &amp;To:</string>
+          </property>
+          <property name="alignment">
+            <set>Qt::AlignLeft|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="buddy">
+            <cstring>payTo</cstring>
+          </property>
+        </widget>
+      </item>
+      <item row="4" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <property name="spacing">
+            <number>0</number>
+          </property>
+          <item>
+            <widget class="QValidatedLineEdit" name="addAsLabel">
+              <property name="enabled">
+                <bool>true</bool>
+              </property>
+              <property name="toolTip">
+                <string>Enter a label for this address to add it to your address book</string>
+              </property>
+            </widget>
+          </item>
+        </layout>
+      </item>
+      <item row="4" column="0">
+        <widget class="QLabel" name="label_4">
+          <property name="text">
+            <string>&amp;Label:</string>
+          </property>
+          <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="buddy">
+            <cstring>addAsLabel</cstring>
+          </property>
+        </widget>
+      </item>
+      <item row="3" column="1">
+        <layout class="QHBoxLayout" name="payToLayout">
+          <property name="spacing">
+            <number>0</number>
+          </property>
+          <item>
+            <widget class="QValidatedLineEdit" name="payTo">
+              <property name="toolTip">
+                <string>The address to send the payment to  (e.g. DDd1pVWr8PPAw1z7DRwoUW6maWh5SsnCcp)</string>
+              </property>
+              <property name="maxLength">
+                <number>102</number>
+              </property>
+            </widget>
+          </item>
+          <item>
+            <widget class="QToolButton" name="addressBookButton">
+              <property name="toolTip">
+                <string>Choose address from address book</string>
+              </property>
+              <property name="text">
+                <string/>
+              </property>
+              <property name="icon">
+                <iconset resource="../bitcoin.qrc">
+                  <normaloff>:/icons/address-book_filled</normaloff>:/icons/address-book_filled                                                                                                                            
+                </iconset>
+              </property>
+              <property name="shortcut">
+                <string>Alt+A</string>
+              </property>
+            </widget>
+          </item>
+          <item>
+            <widget class="QToolButton" name="pasteButton">
+              <property name="toolTip">
+                <string>Paste address from clipboard</string>
+              </property>
+              <property name="text">
+                <string/>
+              </property>
+              <property name="icon">
+                <iconset resource="../bitcoin.qrc">
+                  <normaloff>:/icons/editpaste</normaloff>:/icons/editpaste                                                                                                                            
+                </iconset>
+              </property>
+              <property name="shortcut">
+                <string>Alt+P</string>
+              </property>
+            </widget>
+          </item>
+          <item>
+            <widget class="QToolButton" name="deleteButton">
+              <property name="toolTip">
+                <string>Remove this recipient</string>
+              </property>
+              <property name="text">
+                <string/>
+              </property>
+              <property name="icon">
+                <iconset resource="../bitcoin.qrc">
+                  <normaloff>:/icons/remove</normaloff>:/icons/remove                                                                                                                            
+                </iconset>
+              </property>
+            </widget>
+          </item>
+        </layout>
+      </item>
     </layout>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>&amp;Label:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="buddy">
-      <cstring>addAsLabel</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <layout class="QHBoxLayout" name="payToLayout">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QValidatedLineEdit" name="payTo">
-       <property name="toolTip">
-        <string>The address to send the payment to  (e.g. DDd1pVWr8PPAw1z7DRwoUW6maWh5SsnCcp)</string>
-       </property>
-       <property name="maxLength">
-        <number>102</number>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="addressBookButton">
-       <property name="toolTip">
-        <string>Choose address from address book</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="../bitcoin.qrc">
-         <normaloff>:/icons/address-book_filled</normaloff>:/icons/address-book_filled</iconset>
-       </property>
-       <property name="shortcut">
-        <string>Alt+A</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="pasteButton">
-       <property name="toolTip">
-        <string>Paste address from clipboard</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="../bitcoin.qrc">
-         <normaloff>:/icons/editpaste</normaloff>:/icons/editpaste</iconset>
-       </property>
-       <property name="shortcut">
-        <string>Alt+P</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="deleteButton">
-       <property name="toolTip">
-        <string>Remove this recipient</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="../bitcoin.qrc">
-         <normaloff>:/icons/remove</normaloff>:/icons/remove</iconset>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-  </layout>
- </widget>
- <customwidgets>
-  <customwidget>
-   <class>BitcoinAmountField</class>
-   <extends>QSpinBox</extends>
-   <header>bitcoinamountfield.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QValidatedLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qvalidatedlineedit.h</header>
-  </customwidget>
- </customwidgets>
- <resources>
-  <include location="../bitcoin.qrc"/>
- </resources>
- <connections/>
+  </widget>
+  <customwidgets>
+    <customwidget>
+      <class>BitcoinAmountField</class>
+      <extends>QSpinBox</extends>
+      <header>bitcoinamountfield.h</header>
+      <container>1</container>
+    </customwidget>
+    <customwidget>
+      <class>QValidatedLineEdit</class>
+      <extends>QLineEdit</extends>
+      <header>qvalidatedlineedit.h</header>
+    </customwidget>
+  </customwidgets>
+  <resources>
+    <include location="../bitcoin.qrc"/>
+  </resources>
+  <connections/>
 </ui>

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -44,21 +44,24 @@ void SendCoinsEntry::on_pasteButton_clicked()
     ui->payTo->setText(QApplication::clipboard()->text());
 }
 
-void SendCoinsEntry::on_fullamount_clicked(){
+void SendCoinsEntry::on_fullamount_clicked()
+{
     if(!model)
         return;
 
     ui->payAmount->setValueWithoutComma(model->getAvailableAmount(1));
 }
 
-void SendCoinsEntry::on_halfamount_clicked(){
+void SendCoinsEntry::on_halfamount_clicked()
+{
     if(!model)
         return;
 
     ui->payAmount->setValueWithoutComma(model->getAvailableAmount(2));
 }
 
-void SendCoinsEntry::on_quarteramount_clicked(){
+void SendCoinsEntry::on_quarteramount_clicked()
+{
     if(!model)
         return;
     

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -48,21 +48,21 @@ void SendCoinsEntry::on_fullamount_clicked(){
     if(!model)
         return;
 
-    ui->payAmount->setValue(model->getAvailableAmount(1));
+    ui->payAmount->setValueWithoutComma(model->getAvailableAmount(1));
 }
 
 void SendCoinsEntry::on_halfamount_clicked(){
     if(!model)
         return;
-    
-    ui->payAmount->setValue(model->getAvailableAmount(2));
+
+    ui->payAmount->setValueWithoutComma(model->getAvailableAmount(2));
 }
 
 void SendCoinsEntry::on_quarteramount_clicked(){
     if(!model)
         return;
     
-    ui->payAmount->setValue(model->getAvailableAmount(4));
+    ui->payAmount->setValueWithoutComma(model->getAvailableAmount(4));
 }
 
 void SendCoinsEntry::on_addressBookButton_clicked()

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -44,6 +44,27 @@ void SendCoinsEntry::on_pasteButton_clicked()
     ui->payTo->setText(QApplication::clipboard()->text());
 }
 
+void SendCoinsEntry::on_fullamount_clicked(){
+    if(!model)
+        return;
+
+    ui->payAmount->setValue(model->getAvailableAmount(1));
+}
+
+void SendCoinsEntry::on_halfamount_clicked(){
+    if(!model)
+        return;
+    
+    ui->payAmount->setValue(model->getAvailableAmount(2));
+}
+
+void SendCoinsEntry::on_quarteramount_clicked(){
+    if(!model)
+        return;
+    
+    ui->payAmount->setValue(model->getAvailableAmount(4));
+}
+
 void SendCoinsEntry::on_addressBookButton_clicked()
 {
     if(!model)
@@ -134,7 +155,7 @@ SendCoinsRecipient SendCoinsEntry::getValue()
     rv.label = ui->addAsLabel->text();
     rv.amount = ui->payAmount->value();
 
- if (rv.address.length() > 75 
+    if (rv.address.length() > 75 
         && IsStealthAddress(rv.address.toStdString()))
         rv.typeInd = AddressTableModel::AT_Stealth;
     else

--- a/src/qt/sendcoinsentry.h
+++ b/src/qt/sendcoinsentry.h
@@ -44,6 +44,9 @@ private slots:
     void on_deleteButton_clicked();
     void on_payTo_textChanged(const QString &address);
     void on_addressBookButton_clicked();
+    void on_fullamount_clicked();
+    void on_halfamount_clicked();
+    void on_quarteramount_clicked();
     void on_pasteButton_clicked();
     void updateDisplayUnit();
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -9,11 +9,12 @@
 #include "walletdb.h" // for BackupWallet
 #include "base58.h"
 #include "smessage.h"
+#include "util.h"
 
 #include <QSet>
 #include <QTimer>
 
-WalletModel::WalletModel(CWallet *wallet, OptionsModel *optionsModel, QObject *parent) :
+WalletModel::WalletModel(CWallet *wallet, OptionsModel *optionsModel, QObject *parent) : 
     QObject(parent), wallet(wallet), optionsModel(optionsModel), addressTableModel(0),
     transactionTableModel(0),
     cachedBalance(0), cachedUnconfirmedBalance(0), cachedImmatureBalance(0),
@@ -50,6 +51,23 @@ qint64 WalletModel::getUnconfirmedBalance() const
 qint64 WalletModel::getImmatureBalance() const
 {
     return wallet->GetImmatureBalance();
+}
+
+qint64 WalletModel::getAvailableAmount(int parts) const
+{
+    qint64 balance = getBalance();
+    if(parts <= 0 || !MoneyRange(balance)){
+        return 0;
+    }
+
+    qint64 transaction_amount = (balance / parts) - nTransactionFee;
+
+    if(parts <= 0 || !MoneyRange(transaction_amount)){
+        std::cout << "Out of range error after calculation" << std::endl;
+        return 0;
+    }
+
+    return transaction_amount;
 }
 
 int WalletModel::getNumTransactions() const

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -56,13 +56,15 @@ qint64 WalletModel::getImmatureBalance() const
 qint64 WalletModel::getAvailableAmount(int parts) const
 {
     qint64 balance = getBalance();
-    if(parts <= 0 || !MoneyRange(balance)){
+    if(parts <= 0 || !MoneyRange(balance))
+    {
         return 0;
     }
 
     qint64 transaction_amount = (balance / parts) - nTransactionFee;
 
-    if(parts <= 0 || !MoneyRange(transaction_amount)){
+    if(parts <= 0 || !MoneyRange(transaction_amount))
+    {
         std::cout << "Out of range error after calculation" << std::endl;
         return 0;
     }

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -69,6 +69,7 @@ public:
     qint64 getBalance() const;
     qint64 getUnconfirmedBalance() const;
     qint64 getImmatureBalance() const;
+    qint64 getAvailableAmount(int parts) const;
     int getNumTransactions() const;
     EncryptionStatus getEncryptionStatus() const;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Continuation of  @marpme PR #494 as I have no write permissions. Issue was that BitcoinUnits::format "formats" with commas since commit 6a3f25ba7aad1c004d1bd7cf09d8cf5b70f07259 , and this does not work well with a Spinbox.

Question is. Do we want a 75% button as well?

## Description
<!--- Describe your changes in detail -->
Adds a flag to BitcoinUnits::format that allows formatting without any commas.

## Related Issue
Closes #406 

## How Has This Been Tested?
Ubuntu 16.04
Have tested so that 25% 50% and 100% outputs correct values.

## Screenshots (if appropriate):
![amount](https://user-images.githubusercontent.com/11488530/35282070-e2b06c12-0054-11e8-946d-b3f1a41c0ff5.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


