### PR TITLE
Update go.sh to include required dependencies

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -66,6 +66,8 @@ sudo apt-get -y install libqt5gui5 libqt5core5a libqt5webkit5-dev libqt5dbus5 qt
 
 sudo apt-get -y install libminiupnpc-dev
 
+sudo apt-get -y install libseccomp-dev libcap-dev
+
 # Keep current version of libboost if already present
 results=$(find /usr/ -name libboost_chrono.so)
 if [ -z $results ]; then


### PR DESCRIPTION
## Description
Updated go.sh to include the dependencies needed to compile on Ubuntu.

Missing libseccomp-dev libcap-dev inside the 'go.sh' file.

./configure on Ubuntu fails due to missing dependencies, and make file is not created.

## Related Issue
no related issue at this time since manual compile works appropriately.

## Motivation and Context
This is required to run the single line command that executes the go.sh file.

## How Has This Been Tested?
This was tested on Ubuntu OpenBox desktop.  

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
