### PR TITLE
Fix memcpy of garlicat to actually be garlicat

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -636,7 +636,7 @@ bool CNetAddr::SetSpecial(const std::string &strName)
         std::vector<unsigned char> vchAddr = DecodeBase32(strName.substr(0, strName.size() - 11).c_str());
         if (vchAddr.size() != 16-sizeof(pchGarliCat))
             return false;
-        memcpy(ip, pchOnionCat, sizeof(pchGarliCat));
+        memcpy(ip, pchGarliCat, sizeof(pchGarliCat));
         for (unsigned int i=0; i<16-sizeof(pchGarliCat); i++)
             ip[i + sizeof(pchGarliCat)] = vchAddr[i];
         return true;


### PR DESCRIPTION
Unsure if this code ever properly worked since it's copying the wrong magic bytes.

## Description
The garlicat magic bytes have been incorrect since original import.

## Related Issue
No related issue, however if this isn't considered important it might be worth just removing the excess code.

## Motivation and Context
This code cannot properly work as designed with the current code.

## How Has This Been Tested?
Just code analysis.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
