### PR TITLE
Added a new rpc command for exporting stealth addresses

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -274,6 +274,7 @@ static const CRPCCommand vRPCCommands[] =
     { "getnewstealthaddress",   &getnewstealthaddress,   false,  false},
     { "liststealthaddresses",   &liststealthaddresses,   false,  false},
     { "importstealthaddress",   &importstealthaddress,   false,  false},
+    { "exportstealthaddress",   &exportstealthaddress,   false,  false},
     { "sendtostealthaddress",   &sendtostealthaddress,   false,  false},
     { "scanforalltxns",         &scanforalltxns,         false,  false},
     { "scanforstealthtxns",     &scanforstealthtxns,     false,  false},

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -207,6 +207,7 @@ extern json_spirit::Value getcheckpoint(const json_spirit::Array& params, bool f
 extern json_spirit::Value getnewstealthaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value liststealthaddresses(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value importstealthaddress(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value exportstealthaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value sendtostealthaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value clearwallettransactions(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value scanforalltxns(const json_spirit::Array& params, bool fHelp);

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1960,6 +1960,38 @@ Value importstealthaddress(const Array& params, bool fHelp)
     return result;
 }
 
+Value exportstealthaddress(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+            "exportstealthaddress <label/address>\n"
+            "Exports the given stealth address.");
+
+    std::string stealth_address_label = params[0].get_str();
+    
+    if (pwalletMain->IsLocked())
+        throw runtime_error("Failed: Wallet must be unlocked.");
+    
+    Object result;
+    
+    std::set<CStealthAddress>::iterator it;
+    for (it = pwalletMain->stealthAddresses.begin(); it != pwalletMain->stealthAddresses.end(); ++it)
+    {
+        if (it->scan_secret.size() < 1)
+            continue; // stealth address is not owned
+        
+        if (stealth_address_label == it->label || stealth_address_label == it->Encoded())
+        {
+            Object objA;
+            objA.push_back(Pair("scan_secret", HexStr(it->scan_secret.begin(), it->scan_secret.end())));
+            objA.push_back(Pair("spend_secret", HexStr(it->spend_secret.begin(), it->spend_secret.end())));
+            objA.push_back(Pair("label", it->label));
+            return objA;
+        } 
+    };
+
+    return result;
+}
 
 Value sendtostealthaddress(const Array& params, bool fHelp)
 {


### PR DESCRIPTION
With this you will be able to export a stealth address
by a given address or a label.

![image](https://user-images.githubusercontent.com/7430964/38699963-d9a25f26-3e99-11e8-8d93-28dc3da1cf3d.png)


## Description
See issue/feature #662 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
compiled and tested on ubuntu 16.04 LTS

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
