### PR TITLE
Sudo Causing Tor to require admin privileges

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -135,7 +135,7 @@ fi
 git clone --recurse-submodules https://github.com/vergecurrency/VERGE
 cd ~
 cd VERGE
-sudo ./autogen.sh
+./autogen.sh
 chmod 777 ~/VERGE/share/genbuild.sh
 chmod 777 ~/VERGE/src/leveldb/build_detect_platform
 


### PR DESCRIPTION
Sudo Causing tor to not ./configure correctly when running ./autogen.sh as sudo
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed Sudo before ./autogen.sh  This was causing tor to be installed as Sudo and causing Initializing the tor installation error: 

"config.status: creating contrib/dist/suse/tor.sh
mv: cannot move './confE6vHIf/out' to 'contrib/dist/suse/tor.sh': Permission denied
config.status: error: could not create contrib/dist/suse/tor.sh
configure: error: ./configure failed for tor"

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Testing on local machine Ubuntu 16.04
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
