### PR TITLE
Flush buffers for new wallet

### DIFF
--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -373,6 +373,7 @@ bool CTxDB::LoadBlockIndex(CClientUIInterface* uiInterface)
 
             // prints the block index percentage to the console if -printtoconsole is given
             printf("Loading block index %2.f%% ...\n",((count * 100.0) / full_count));
+            fflush(stdout); // Will now print everything in the stdout buffer
         }
         boost::this_thread::interruption_point();
         // Unpack keys and values.


### PR DESCRIPTION
Flushing buffers is necessary since the wallet needs to read in the output of this process and it can't do it unless the buffer is constantly flushed.