### PR TITLE
Adding additional output for the getinfo command

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -103,7 +103,7 @@ Value getinfo(const Array& params, bool fHelp)
     obj.push_back(Pair("keypoolsize",   pwalletMain->GetKeyPoolSize()));
     obj.push_back(Pair("paytxfee",      ValueFromAmount(nTransactionFee)));
     obj.push_back(Pair("isunlocked",    !pwalletMain->IsLocked()));
-    // leaving the unlocked until for backward compatability.
+    // leaving the unlocked until for backward compatibility.
     if (pwalletMain->IsCrypted())
         obj.push_back(Pair("unlocked_until", (boost::int64_t)nWalletUnlockTime / 1000));
     obj.push_back(Pair("errors",        GetWarnings("statusbar")));

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -102,6 +102,8 @@ Value getinfo(const Array& params, bool fHelp)
     obj.push_back(Pair("keypoololdest", (boost::int64_t)pwalletMain->GetOldestKeyPoolTime()));
     obj.push_back(Pair("keypoolsize",   pwalletMain->GetKeyPoolSize()));
     obj.push_back(Pair("paytxfee",      ValueFromAmount(nTransactionFee)));
+    obj.push_back(Pair("isunlocked",    !pwalletMain->IsLocked()));
+    // leaving the unlocked until for backward compatability.
     if (pwalletMain->IsCrypted())
         obj.push_back(Pair("unlocked_until", (boost::int64_t)nWalletUnlockTime / 1000));
     obj.push_back(Pair("errors",        GetWarnings("statusbar")));

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -373,6 +373,7 @@ bool CTxDB::LoadBlockIndex(CClientUIInterface* uiInterface)
 
             // prints the block index percentage to the console if -printtoconsole is given
             printf("Loading block index %2.f%% ...\n",((count * 100.0) / full_count));
+            fflush(stdout); // Will now print everything in the stdout buffer
         }
         boost::this_thread::interruption_point();
         // Unpack keys and values.


### PR DESCRIPTION
The new wallet needs a standard way of handling locking and unlocking the wallet.
So therefor I added a `isunlocked` field to quickly check if the wallet is really locked or not.

Kept the old option for backward compatibility.