### PR TITLE
Update go.sh

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -1,33 +1,6 @@
 #!/bin/bash
 #// full deployement : run sh go.sh
 
-# generating entropy make it harder to guess the randomness!.
-echo "Initializing random number generator..."
-random_seed=/var/run/random-seed
-# Carry a random seed from start-up to start-up
-# Load and then save the whole entropy pool
-if [ -f $random_seed ]; then
-    sudo cat $random_seed >/dev/urandom
-else
-    sudo touch $random_seed
-fi
-sudo chmod 600 $random_seed
-poolfile=/proc/sys/kernel/random/poolsize
-[ -r $poolfile ] && bytes=`sudo cat $poolfile` || bytes=512
-sudo dd if=/dev/urandom of=$random_seed count=1 bs=$bytes
-
-#Also, add the following lines in an appropriate script which is run during the$
-
-# Carry a random seed from shut-down to start-up
-# Save the whole entropy pool
-echo "Saving random seed..."
-random_seed=/var/run/random-seed
-sudo touch $random_seed
-sudo chmod 600 $random_seed
-poolfile=/proc/sys/kernel/random/poolsize
-[ -r $poolfile ] && bytes=`sudo cat $poolfile` || bytes=512
-sudo dd if=/dev/urandom of=$random_seed count=1 bs=$bytes
-
 # Create a swap file
 
 cd ~


### PR DESCRIPTION
According to this:
https://github.com/torvalds/linux/blob/master/drivers/char/random.c:

///////////////////////////////////////////////////////////////////
Ensuring unpredictability at system startup

When any operating system starts up, it will go through a sequence
of actions that are fairly predictable by an adversary, especially
if the start-up does not involve interaction with a human operator.
This reduces the actual number of bits of unpredictability in the
entropy pool below the value in entropy_count. In order to
counteract this effect, it helps to carry information in the
entropy pool across shut-downs and start-ups. To do this, put the
following lines an appropriate script which is run during the boot
sequence:

	echo "Initializing random number generator..."
	random_seed=/var/run/random-seed
	# Carry a random seed from start-up to start-up
	# Load and then save the whole entropy pool
	if [ -f $random_seed ]; then
		cat $random_seed >/dev/urandom
	else
		touch $random_seed
	fi
	chmod 600 $random_seed
	dd if=/dev/urandom of=$random_seed count=1 bs=512

and the following lines in an appropriate script which is run as
the system is shutdown:

	# Carry a random seed from shut-down to start-up
	# Save the whole entropy pool
	echo "Saving random seed..."
	random_seed=/var/run/random-seed
	touch $random_seed
	chmod 600 $random_seed
	dd if=/dev/urandom of=$random_seed count=1 bs=512

For example, on most modern systems using the System V init
scripts, such code fragments would be found in
/etc/rc.d/init.d/random.  On older Linux systems, the correct script
location might be in /etc/rcb.d/rc.local or /etc/rc.d/rc.0.

Effectively, these commands cause the contents of the entropy pool
to be saved at shut-down time and reloaded into the entropy pool at
start-up.  (The 'dd' in the addition to the bootup script is to
make sure that /etc/random-seed is different for every start-up,
even if the system crashes without executing rc.0.)  Even with
complete knowledge of the start-up activities, predicting the state
of the entropy pool requires knowledge of the previous history of
the system.
///////////////////////////////////////////////////////////////////

So, if user really wants to "ensure unpredictability" (provided that start-ups do not involve much interaction with a human operator) - these parts need to be put in an appropriate start-up and shut-down scripts of the user's system, not this compilation/installation script, which is already bloated with unnecessary things.
