### PR TITLE
refactor block logic

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#// full deployement :   wget -O - https://raw.githubusercontent.com/badbrainIRC/VERGE/patch-8/go.sh | bash
+#// full deployement :   wget -O - https://raw.githubusercontent.com/badbrainIRC/VERGE/go.sh | bash
 sudo rm -Rf ~/VERGE
 # generating entropy make it harder to guess the randomness!.
 echo "Initializing random number generator..."
@@ -191,11 +191,11 @@ cd ~
 if [ -d /usr/local/BerkeleyDB.4.8/include ]
 then
 cd VERGE
-./configure CXXFLAGS="--param ggc-min-expand=1 --param ggc-min-heapsize=32768" CPPFLAGS="-I/usr/local/BerkeleyDB.4.8/include -O2 -flto" LDFLAGS="-L/usr/local/BerkeleyDB.4.8/lib" --with-gui=qt5 --with-boost-libdir=$(dirname "$(cat wrd0$answer.txt)") --disable-bench --disable-tests --disable-gui-tests --without-miniupnpc
+./configure CXXFLAGS="--param ggc-min-expand=1 --param ggc-min-heapsize=32768" CPPFLAGS="-I/usr/local/BerkeleyDB.4.8/include -O2" LDFLAGS="-L/usr/local/BerkeleyDB.4.8/lib" --with-gui=qt5 --with-boost-libdir=$(dirname "$(cat wrd0$answer.txt)") --disable-bench --disable-tests --disable-gui-tests --without-miniupnpc
 echo "Using Berkeley Generic..."
 else
 cd VERGE
-./configure CXXFLAGS="--param ggc-min-expand=1 --param ggc-min-heapsize=32768" CPPFLAGS="-O2 -flto" --with-gui=qt5 --with-boost-libdir=$(dirname "$(cat wrd0$answer.txt)") --disable-bench --disable-tests --disable-gui-tests --without-miniupnpc
+./configure CXXFLAGS="--param ggc-min-expand=1 --param ggc-min-heapsize=32768" CPPFLAGS="-O2" --with-gui=qt5 --with-boost-libdir=$(dirname "$(cat wrd0$answer.txt)") --disable-bench --disable-tests --disable-gui-tests --without-miniupnpc
 echo "Using default system Berkeley..."
 fi
 
@@ -220,7 +220,15 @@ if [ -e ~/.VERGE/VERGE.conf ]
 then
     cp -a ~/.VERGE/VERGE.conf ~/.VERGE/VERGE.bak
 fi
-echo "rpcuser="$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 26 ; echo '') '\n'"rpcpassword="$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 26 ; echo '') '\n'"rpcport=20102" '\n'"port=21102" '\n'"daemon=1" '\n'"listen=1" '\n'"server=1" '\n'"deprecatedrpc=accounts" '\n'"" '\n'"" '\n'"" '\n'"" '\n'"" '\n'"" '\n'"" '\n'"" '\n'"" '\n'"" '\n'"" '\n'"" '\n'"" '\n'"" '\n'"" '\n'""> ~/.VERGE/VERGE.conf
+rm ~/.VERGE/VERGE.conf
+echo "rpcuser="$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 26) >> ~/.VERGE/VERGE.conf
+echo "rpcpassword="$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 26) >> ~/.VERGE/VERGE.conf
+echo "rpcport=20102" >> ~/.VERGE/VERGE.conf
+echo "port=21102" >> ~/.VERGE/VERGE.conf
+echo "daemon=1" >> ~/.VERGE/VERGE.conf
+echo "listen=1" >> ~/.VERGE/VERGE.conf
+echo "server=1" >> ~/.VERGE/VERGE.conf
+echo "deprecatedrpc=accounts" >> ~/.VERGE/VERGE.conf
 
 #// Extract http link, download blockchain and install it.
 
@@ -230,7 +238,17 @@ sudo echo "FORCE_SSL_PROMPT:YES" >> /etc/lynx/lynx.cfg
 # Create Icon on Desktop and in menu
 mkdir -p ~/Desktop/
 sudo cp ~/VERGE/src/qt/res/icons/verge.png /usr/share/icons/
-echo '#!/usr/bin/env xdg-open''\n'"[Desktop Entry]"'\n'"Version=1.0"'\n'"Type=Application"'\n'"Terminal=false"'\n'"Icon[en]=/usr/share/icons/verge.png"'\n'"Name[en]=VERGE"'\n'"Exec=verge-qt"'\n'"Name=VERGE"'\n'"Icon=/usr/share/icons/verge.png"'\n'"Categories=Network;Internet;" > ~/Desktop/VERGE.desktop
+echo "#!/usr/bin/env xdg-open" >> ~/Desktop/VERGE.desktop
+echo "[Desktop Entry]" >> ~/Desktop/VERGE.desktop
+echo "Version=1.0" >> ~/Desktop/VERGE.desktop
+echo "Type=Application" >> ~/Desktop/VERGE.desktop
+echo "Terminal=false" >> ~/Desktop/VERGE.desktop
+echo "Icon[en]=/usr/share/icons/verge.png" >> ~/Desktop/VERGE.desktop
+echo "Name[en]=VERGE" >> ~/Desktop/VERGE.desktop
+echo "Exec=verge-qt" >> ~/Desktop/VERGE.desktop
+echo "Name=VERGE" >> ~/Desktop/VERGE.desktop
+echo "Icon=/usr/share/icons/verge.png" >> ~/Desktop/VERGE.desktop
+echo "Categories=Network;Internet;" >> ~/Desktop/VERGE.desktop
 sudo chmod +x ~/Desktop/VERGE.desktop
 sudo cp ~/Desktop/VERGE.desktop /usr/share/applications/VERGE.desktop
 sudo chmod +x /usr/share/applications/VERGE.desktop
@@ -238,7 +256,7 @@ sudo chmod +x /usr/share/applications/VERGE.desktop
 # Erase all VERGE compilation directory , cleaning
 
 cd ~
-sudo rm -Rf ~/VERGE
+#sudo rm -Rf ~/VERGE
 
 # Blockchain
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -159,6 +159,7 @@ VERGE_CORE_H = \
   core_io.h \
   core_memusage.h \
   cuckoocache.h \
+  flatfile.h \
   stealth.h \
   fs.h \
   httprpc.h \
@@ -268,6 +269,7 @@ libverge_server_a_SOURCES = \
   chain.cpp \
   checkpoints.cpp \
   consensus/tx_verify.cpp \
+  flatfile.cpp \
   httprpc.cpp \
   httpserver.cpp \
   index/base.cpp \

--- a/src/Makefile.qttest.include
+++ b/src/Makefile.qttest.include
@@ -28,10 +28,10 @@ TEST_QT_H = \
   qt/test/wallettests.h
 
 TEST_VERGE_CPP = \
-  test/test_verge.cpp
+  test/setup_common.cpp
 
 TEST_VERGE_H = \
-  test/test_verge.h
+  test/setup_common.h
 
 qt_test_test_verge_qt_CPPFLAGS = $(AM_CPPFLAGS) $(VERGE_INCLUDES) $(VERGE_QT_INCLUDES) \
   $(QT_INCLUDES) $(QT_TEST_INCLUDES) $(PROTOBUF_CFLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -47,6 +47,7 @@ VERGE_TESTS =\
   test/crypto_tests.cpp \
   test/cuckoocache_tests.cpp \
   test/denialofservice_tests.cpp \
+  test/flatfile_tests.cpp \
   test/getarg_tests.cpp \
   test/hash_tests.cpp \
   test/key_io_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -22,8 +22,8 @@ GENERATED_TEST_FILES = $(JSON_TEST_FILES:.json=.json.h) $(RAW_TEST_FILES:.raw=.r
 
 VERGE_TEST_SUITE = \
   test/test_verge_main.cpp \
-  test/test_verge.h \
-  test/test_verge.cpp
+  test/setup_common.h \
+  test/setup_common.cpp
 
 # test_verge binary #
 VERGE_TESTS =\

--- a/src/chain.h
+++ b/src/chain.h
@@ -9,6 +9,7 @@
 
 #include <arith_uint256.h>
 #include <consensus/params.h>
+#include <flatfile.h>
 #include <primitives/block.h>
 #include <tinyformat.h>
 #include <uint256.h>
@@ -113,46 +114,6 @@ public:
          if (nTimeIn > nTimeLast)
              nTimeLast = nTimeIn;
      }
-};
-
-struct CDiskBlockPos
-{
-    int nFile;
-    unsigned int nPos;
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(VARINT(nFile, VarIntMode::NONNEGATIVE_SIGNED));
-        READWRITE(VARINT(nPos));
-    }
-
-    CDiskBlockPos() {
-        SetNull();
-    }
-
-    CDiskBlockPos(int nFileIn, unsigned int nPosIn) {
-        nFile = nFileIn;
-        nPos = nPosIn;
-    }
-
-    friend bool operator==(const CDiskBlockPos &a, const CDiskBlockPos &b) {
-        return (a.nFile == b.nFile && a.nPos == b.nPos);
-    }
-
-    friend bool operator!=(const CDiskBlockPos &a, const CDiskBlockPos &b) {
-        return !(a == b);
-    }
-
-    void SetNull() { nFile = -1; nPos = 0; }
-    bool IsNull() const { return (nFile == -1); }
-
-    std::string ToString() const
-    {
-        return strprintf("CDiskBlockPos(nFile=%i, nPos=%i)", nFile, nPos);
-    }
-
 };
 
 enum BlockStatus: uint32_t {
@@ -291,8 +252,8 @@ public:
         nNonce         = block.nNonce;
     }
 
-    CDiskBlockPos GetBlockPos() const {
-        CDiskBlockPos ret;
+    FlatFilePos GetBlockPos() const {
+        FlatFilePos ret;
         if (nStatus & BLOCK_HAVE_DATA) {
             ret.nFile = nFile;
             ret.nPos  = nDataPos;
@@ -300,8 +261,8 @@ public:
         return ret;
     }
 
-    CDiskBlockPos GetUndoPos() const {
-        CDiskBlockPos ret;
+    FlatFilePos GetUndoPos() const {
+        FlatFilePos ret;
         if (nStatus & BLOCK_HAVE_UNDO) {
             ret.nFile = nFile;
             ret.nPos  = nUndoPos;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -158,6 +158,9 @@ public:
             vSeeds.emplace_back("6telhbsuva4qkff2.onion");
         } else {
             vSeeds.emplace_back("185.162.9.97");
+	    vSeeds.emplace_back("159.89.46.252"); // v5-new-york
+	    vSeeds.emplace_back("139.59.34.170"); // v5-india
+	    vSeeds.emplace_back("134.209.197.243"); // v5-NL
             vSeeds.emplace_back("104.131.144.82");
             vSeeds.emplace_back("192.241.187.222");
             vSeeds.emplace_back("105.228.198.44");

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -1,0 +1,98 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <stdexcept>
+
+#include <flatfile.h>
+#include <logging.h>
+#include <tinyformat.h>
+#include <util/system.h>
+
+FlatFileSeq::FlatFileSeq(fs::path dir, const char* prefix, size_t chunk_size) :
+    m_dir(std::move(dir)),
+    m_prefix(prefix),
+    m_chunk_size(chunk_size)
+{
+    if (chunk_size == 0) {
+        throw std::invalid_argument("chunk_size must be positive");
+    }
+}
+
+std::string FlatFilePos::ToString() const
+{
+    return strprintf("FlatFilePos(nFile=%i, nPos=%i)", nFile, nPos);
+}
+
+fs::path FlatFileSeq::FileName(const FlatFilePos& pos) const
+{
+    return m_dir / strprintf("%s%05u.dat", m_prefix, pos.nFile);
+}
+
+FILE* FlatFileSeq::Open(const FlatFilePos& pos, bool read_only)
+{
+    if (pos.IsNull()) {
+        return nullptr;
+    }
+    fs::path path = FileName(pos);
+    fs::create_directories(path.parent_path());
+    FILE* file = fsbridge::fopen(path, read_only ? "rb": "rb+");
+    if (!file && !read_only)
+        file = fsbridge::fopen(path, "wb+");
+    if (!file) {
+        LogPrintf("Unable to open file %s\n", path.string());
+        return nullptr;
+    }
+    if (pos.nPos && fseek(file, pos.nPos, SEEK_SET)) {
+        LogPrintf("Unable to seek to position %u of %s\n", pos.nPos, path.string());
+        fclose(file);
+        return nullptr;
+    }
+    return file;
+}
+
+size_t FlatFileSeq::Allocate(const FlatFilePos& pos, size_t add_size, bool& out_of_space)
+{
+    out_of_space = false;
+
+    unsigned int n_old_chunks = (pos.nPos + m_chunk_size - 1) / m_chunk_size;
+    unsigned int n_new_chunks = (pos.nPos + add_size + m_chunk_size - 1) / m_chunk_size;
+    if (n_new_chunks > n_old_chunks) {
+        size_t old_size = pos.nPos;
+        size_t new_size = n_new_chunks * m_chunk_size;
+        size_t inc_size = new_size - old_size;
+
+        if (CheckDiskSpace(m_dir, inc_size)) {
+            FILE *file = Open(pos);
+            if (file) {
+                LogPrintf("Pre-allocating up to position 0x%x in %s%05u.dat\n", new_size, m_prefix, pos.nFile);
+                AllocateFileRange(file, pos.nPos, inc_size);
+                fclose(file);
+                return inc_size;
+            }
+        } else {
+            out_of_space = true;
+        }
+    }
+    return 0;
+}
+
+bool FlatFileSeq::Flush(const FlatFilePos& pos, bool finalize)
+{
+    FILE* file = Open(FlatFilePos(pos.nFile, 0)); // Avoid fseek to nPos
+    if (!file) {
+        return error("%s: failed to open file %d", __func__, pos.nFile);
+    }
+    if (finalize && !TruncateFile(file, pos.nPos)) {
+        fclose(file);
+        return error("%s: failed to truncate file %d", __func__, pos.nFile);
+    }
+    if (!FileCommit(file)) {
+        fclose(file);
+        return error("%s: failed to commit file %d", __func__, pos.nFile);
+    }
+
+    fclose(file);
+    return true;
+}

--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -1,0 +1,96 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef VERGE_FLATFILE_H
+#define VERGE_FLATFILE_H
+
+#include <string>
+
+#include <fs.h>
+#include <serialize.h>
+
+struct FlatFilePos
+{
+    int nFile;
+    unsigned int nPos;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(VARINT(nFile, VarIntMode::NONNEGATIVE_SIGNED));
+        READWRITE(VARINT(nPos));
+    }
+
+    FlatFilePos() : nFile(-1), nPos(0) {}
+
+    FlatFilePos(int nFileIn, unsigned int nPosIn) :
+        nFile(nFileIn),
+        nPos(nPosIn)
+    {}
+
+    friend bool operator==(const FlatFilePos &a, const FlatFilePos &b) {
+        return (a.nFile == b.nFile && a.nPos == b.nPos);
+    }
+
+    friend bool operator!=(const FlatFilePos &a, const FlatFilePos &b) {
+        return !(a == b);
+    }
+
+    void SetNull() { nFile = -1; nPos = 0; }
+    bool IsNull() const { return (nFile == -1); }
+
+    std::string ToString() const;
+};
+
+/**
+ * FlatFileSeq represents a sequence of numbered files storing raw data. This class facilitates
+ * access to and efficient management of these files.
+ */
+class FlatFileSeq
+{
+private:
+    const fs::path m_dir;
+    const char* const m_prefix;
+    const size_t m_chunk_size;
+
+public:
+    /**
+     * Constructor
+     *
+     * @param dir The base directory that all files live in.
+     * @param prefix A short prefix given to all file names.
+     * @param chunk_size Disk space is pre-allocated in multiples of this amount.
+     */
+    FlatFileSeq(fs::path dir, const char* prefix, size_t chunk_size);
+
+    /** Get the name of the file at the given position. */
+    fs::path FileName(const FlatFilePos& pos) const;
+
+    /** Open a handle to the file at the given position. */
+    FILE* Open(const FlatFilePos& pos, bool read_only = false);
+
+    /**
+     * Allocate additional space in a file after the given starting position. The amount allocated
+     * will be the minimum multiple of the sequence chunk size greater than add_size.
+     *
+     * @param[in] pos The starting position that bytes will be allocated after.
+     * @param[in] add_size The minimum number of bytes to be allocated.
+     * @param[out] out_of_space Whether the allocation failed due to insufficient disk space.
+     * @return The number of bytes successfully allocated.
+     */
+    size_t Allocate(const FlatFilePos& pos, size_t add_size, bool& out_of_space);
+
+    /**
+     * Commit a file to disk, and optionally truncate off extra pre-allocated bytes if final.
+     *
+     * @param[in] pos The first unwritten position in the file to be flushed.
+     * @param[in] finalize True if no more data will be written to this file.
+     * @return true on success, false on failure.
+     */
+    bool Flush(const FlatFilePos& pos, bool finalize = false);
+};
+
+#endif // VERGE_FLATFILE_H

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -17,7 +17,7 @@ constexpr char DB_TXINDEX_BLOCK = 'T';
 
 std::unique_ptr<TxIndex> g_txindex;
 
-struct CDiskTxPos : public CDiskBlockPos
+struct CDiskTxPos : public FlatFilePos
 {
     unsigned int nTxOffset; // after header
 
@@ -25,11 +25,11 @@ struct CDiskTxPos : public CDiskBlockPos
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITEAS(CDiskBlockPos, *this);
+        READWRITEAS(FlatFilePos, *this);
         READWRITE(VARINT(nTxOffset));
     }
 
-    CDiskTxPos(const CDiskBlockPos &blockIn, unsigned int nTxOffsetIn) : CDiskBlockPos(blockIn.nFile, blockIn.nPos), nTxOffset(nTxOffsetIn) {
+    CDiskTxPos(const FlatFilePos &blockIn, unsigned int nTxOffsetIn) : FlatFilePos(blockIn.nFile, blockIn.nPos), nTxOffset(nTxOffsetIn) {
     }
 
     CDiskTxPos() {
@@ -37,7 +37,7 @@ struct CDiskTxPos : public CDiskBlockPos
     }
 
     void SetNull() {
-        CDiskBlockPos::SetNull();
+        FlatFilePos::SetNull();
         nTxOffset = 0;
     }
 };

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -654,8 +654,8 @@ static void ThreadImport(std::vector<fs::path> vImportFiles)
     if (fReindex) {
         int nFile = 0;
         while (true) {
-            CDiskBlockPos pos(nFile, 0);
-            if (!fs::exists(GetBlockPosFilename(pos, "blk")))
+            FlatFilePos pos(nFile, 0);
+            if (!fs::exists(GetBlockPosFilename(pos)))
                 break; // No block files left to reindex
             FILE *file = OpenBlockFile(pos, true);
             if (!file)
@@ -1681,8 +1681,14 @@ bool AppInitMain()
 
     // ********************************************************* Step 11: import blocks
 
-    if (!CheckDiskSpace() && !CheckDiskSpace(0, true))
+    if (!CheckDiskSpace(GetDataDir())) {
+        InitError(strprintf(_("Error: Disk space is low for %s"), GetDataDir()));
         return false;
+    }
+    if (!CheckDiskSpace(GetBlocksDir())) {
+        InitError(strprintf(_("Error: Disk space is low for %s"), GetBlocksDir()));
+        return false;
+    }
 
     // Either install a handler to notify us when genesis activates, or set fHaveGenesis directly.
     // No locking, as this happens before any background thread is started.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1380,6 +1380,12 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
         if (!LookupBlockIndex(hashLastBlock)) {
             received_new_header = true;
         }
+
+        // we are patiently waiting for new headers to receive
+        // instead we got already known headers ... ignore.
+        if(IsInitialBlockDownload() && !received_new_header) {
+            return true;
+        }
     }
 
     CValidationState state;
@@ -2717,24 +2723,15 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         
         // new clients are sending clean headers
         // but the older version are sending also some addtional stuff with them
-        if (pfrom->nVersion >= 90007) {
-            headers.resize(nCount);
-            for (unsigned int n = 0; n < nCount; n++) {
-                vRecv >> headers[n];
-                ReadCompactSize(vRecv); 
-            }
-        } else {
-            // make sure only HEADERS are being parsed and nothing more!
-            vRecv.SetType(vRecv.GetType() | SER_BLOCKHEADERONLY);
-            blocks.resize(nCount);
-            for (unsigned int n = 0; n < nCount; n++) {
-                vRecv >> blocks[n];
-                ReadCompactSize(vRecv); // ignore tx count; assume it is 0.
-            }
-
-            std::copy(blocks.begin(), blocks.end(), std::back_inserter(headers));
+        // make sure only HEADERS are being parsed and nothing more!
+        vRecv.SetType(vRecv.GetType() | SER_BLOCKHEADERONLY);
+        blocks.resize(nCount);
+        for (unsigned int n = 0; n < nCount; n++) {
+            vRecv >> blocks[n];
+            ReadCompactSize(vRecv); // ignore tx count; assume it is 0.
         }
 
+        std::copy(blocks.begin(), blocks.end(), std::back_inserter(headers));
 
         // Headers received via a HEADERS message should be valid, and reflect
         // the chain the peer is on. If we receive a known-invalid header,

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -639,6 +639,11 @@ bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats) {
     return true;
 }
 
+int GetNumberOfPeersWithValidatedDownloads()
+{
+    return nPeersWithValidatedDownloads;
+}
+
 //////////////////////////////////////////////////////////////////////////////
 //
 // mapOrphanTransactions

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -101,6 +101,11 @@ struct CNodeStateStats {
 /** Get statistics from node state */
 bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats);
 /** Increase a node's misbehavior score. */
-void Misbehaving(NodeId nodeid, int howmuch, const std::string& message="");
+//void Misbehaving(NodeId nodeid, int howmuch, const std::string& message="");
+
+/**
+ * Get number of peers from which we're downloading blocks
+ */
+int GetNumberOfPeersWithValidatedDownloads() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 #endif // VERGE_NET_PROCESSING_H

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -101,7 +101,7 @@ struct CNodeStateStats {
 /** Get statistics from node state */
 bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats);
 /** Increase a node's misbehavior score. */
-//void Misbehaving(NodeId nodeid, int howmuch, const std::string& message="");
+void Misbehaving(NodeId nodeid, int howmuch, const std::string& message="");
 
 /**
  * Get number of peers from which we're downloading blocks

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -19,8 +19,11 @@
 
 int ALGO = ALGO_SCRYPT;
 
-uint256 CBlockHeader::GetHash() const 
+uint256 CBlockHeader::GetHash() const
 {
+    if(!this->hash.IsNull()){
+        return this->hash;
+    }
     return GetPoWHash(ALGO_SCRYPT);
 }
 

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -100,6 +100,8 @@ public:
     uint32_t nBits;
     uint32_t nNonce;
 
+    uint256 hash;
+
     CBlockHeader()
     {
         SetNull();
@@ -116,6 +118,9 @@ public:
         READWRITE(nTime);
         READWRITE(nBits);
         READWRITE(nNonce);
+        if(ser_action.ForRead()){
+            this->hash = GetPoWHash(ALGO_SCRYPT);
+        }
     }
 
     void SetNull()
@@ -123,6 +128,7 @@ public:
         nVersion = 0;
         hashPrevBlock.SetNull();
         hashMerkleRoot.SetNull();
+        hash.SetNull();
         nTime = 0;
         nBits = 0;
         nNonce = 0;

--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -1,6 +1,6 @@
 #include <qt/test/addressbooktests.h>
 #include <qt/test/util.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <interfaces/node.h>
 #include <qt/addressbookpage.h>

--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -13,7 +13,7 @@
 #include <rpc/register.h>
 #include <rpc/server.h>
 #include <qt/rpcconsole.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 #include <univalue.h>
 #include <util/system.h>
 

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -13,7 +13,7 @@
 #include <qt/transactionview.h>
 #include <qt/walletmodel.h>
 #include <key_io.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 #include <validation.h>
 #include <wallet/wallet.h>
 #include <qt/overviewpage.h>

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -42,7 +42,7 @@ unit tests as possible).
 
 The build system is setup to compile an executable called `test_verge`
 that runs all of the unit tests.  The main source file is called
-test_verge.cpp. To add a new unit test file to our test suite you need 
+setup_common.cpp. To add a new unit test file to our test suite you need 
 to add the file to `src/Makefile.test.include`. The pattern is to create 
 one test file for each class or source file for which you want to create 
 unit tests.  The file naming convention is `<source_filename>_tests.cpp` 

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -3,7 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include <addrman.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 #include <string>
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/allocator_tests.cpp
+++ b/src/test/allocator_tests.cpp
@@ -6,7 +6,7 @@
 #include <util/system.h>
 
 #include <support/allocators/secure.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <memory>
 

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <amount.h>
 #include <policy/feerate.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -13,7 +13,7 @@
 #include <arith_uint256.h>
 #include <string>
 #include <version.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 BOOST_FIXTURE_TEST_SUITE(arith_uint256_tests, BasicTestingSetup)
 

--- a/src/test/base32_tests.cpp
+++ b/src/test/base32_tests.cpp
@@ -4,7 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <util/strencodings.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -6,7 +6,7 @@
 #include <test/data/base58_encode_decode.json.h>
 
 #include <base58.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 #include <util/strencodings.h>
 
 #include <univalue.h>

--- a/src/test/base64_tests.cpp
+++ b/src/test/base64_tests.cpp
@@ -4,7 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <util/strencodings.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/bech32_tests.cpp
+++ b/src/test/bech32_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bech32.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -10,7 +10,7 @@
 #include <uint256.h>
 #include <util/system.h>
 #include <util/strencodings.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <string>
 #include <vector>

--- a/src/test/blockchain_tests.cpp
+++ b/src/test/blockchain_tests.cpp
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 
 #include <rpc/blockchain.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 /* Equality between doubles is imprecise. Comparison should be done
  * with a small threshold of tolerance, rather than exact equality.

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -9,7 +9,7 @@
 #include <pow.h>
 #include <random.h>
 
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -3,7 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <blockfilter.h>
 #include <serialize.h>

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -16,7 +16,7 @@
 #include <uint256.h>
 #include <util/system.h>
 #include <util/strencodings.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <vector>
 

--- a/src/test/bswap_tests.cpp
+++ b/src/test/bswap_tests.cpp
@@ -4,7 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <compat/byteswap.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -7,7 +7,7 @@
 #include <util/time.h>
 #include <validation.h>
 
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 #include <checkqueue.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/thread.hpp>

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -8,7 +8,7 @@
 #include <uint256.h>
 #include <undo.h>
 #include <util/strencodings.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 #include <validation.h>
 #include <consensus/validation.h>
 

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <compressor.h>
 #include <util/system.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <stdint.h>
 #include <boost/test/unit_test.hpp>

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -13,7 +13,7 @@
 #include <crypto/hmac_sha512.h>
 #include <random.h>
 #include <util/strencodings.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <vector>
 

--- a/src/test/cuckoocache_tests.cpp
+++ b/src/test/cuckoocache_tests.cpp
@@ -5,7 +5,7 @@
 #include <boost/test/unit_test.hpp>
 #include <cuckoocache.h>
 #include <script/sigcache.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 #include <random.h>
 #include <thread>
 

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -6,7 +6,7 @@
 #include <dbwrapper.h>
 #include <uint256.h>
 #include <random.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <memory>
 
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper)
 {
     // Perform tests both obfuscated and non-obfuscated.
     for (bool obfuscate : {false, true}) {
-        fs::path ph = fs::temp_directory_path() / fs::unique_path();
+        fs::path ph = SetDataDir(std::string("dbwrapper").append(obfuscate ? "_true" : "_false"));
         CDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
         char key = 'k';
         uint256 in = InsecureRand256();
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_batch)
 {
     // Perform tests both obfuscated and non-obfuscated.
     for (bool obfuscate : {false, true}) {
-        fs::path ph = fs::temp_directory_path() / fs::unique_path();
+        fs::path ph = SetDataDir(std::string("dbwrapper_batch").append(obfuscate ? "_true" : "_false"));
         CDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
 
         char key = 'i';
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
 {
     // Perform tests both obfuscated and non-obfuscated.
     for (bool obfuscate : {false, true}) {
-        fs::path ph = fs::temp_directory_path() / fs::unique_path();
+        fs::path ph = SetDataDir(std::string("dbwrapper_iterator").append(obfuscate ? "_true" : "_false"));
         CDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
 
         // The two keys are intentionally chosen for ordering
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
 BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
 {
     // We're going to share this fs::path between two wrappers
-    fs::path ph = fs::temp_directory_path() / fs::unique_path();
+    fs::path ph = SetDataDir("existing_data_no_obfuscate");
     create_directories(ph);
 
     // Set up a non-obfuscated wrapper to write some initial data.
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
 BOOST_AUTO_TEST_CASE(existing_data_reindex)
 {
     // We're going to share this fs::path between two wrappers
-    fs::path ph = fs::temp_directory_path() / fs::unique_path();
+    fs::path ph = SetDataDir("existing_data_reindex");
     create_directories(ph);
 
     // Set up a non-obfuscated wrapper to write some initial data.
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
 
 BOOST_AUTO_TEST_CASE(iterator_ordering)
 {
-    fs::path ph = fs::temp_directory_path() / fs::unique_path();
+    fs::path ph = SetDataDir("iterator_ordering");
     CDBWrapper dbw(ph, (1 << 20), true, false, false);
     for (int x=0x00; x<256; ++x) {
         uint8_t key = x;
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
 {
     char buf[10];
 
-    fs::path ph = fs::temp_directory_path() / fs::unique_path();
+    fs::path ph = SetDataDir("iterator_string_ordering");
     CDBWrapper dbw(ph, (1 << 20), true, false, false);
     for (int x=0x00; x<10; ++x) {
         for (int y = 0; y < 10; y++) {

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -15,7 +15,7 @@
 #include <util/system.h>
 #include <validation.h>
 
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <stdint.h>
 

--- a/src/test/flatfile_tests.cpp
+++ b/src/test/flatfile_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <flatfile.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/flatfile_tests.cpp
+++ b/src/test/flatfile_tests.cpp
@@ -1,0 +1,123 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <flatfile.h>
+#include <test/test_verge.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(flatfile_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(flatfile_filename)
+{
+    auto data_dir = SetDataDir("flatfile_test");
+
+    FlatFilePos pos(456, 789);
+
+    FlatFileSeq seq1(data_dir, "a", 16 * 1024);
+    BOOST_CHECK_EQUAL(seq1.FileName(pos), data_dir / "a00456.dat");
+
+    FlatFileSeq seq2(data_dir / "a", "b", 16 * 1024);
+    BOOST_CHECK_EQUAL(seq2.FileName(pos), data_dir / "a" / "b00456.dat");
+}
+
+BOOST_AUTO_TEST_CASE(flatfile_open)
+{
+    auto data_dir = SetDataDir("flatfile_test");
+    FlatFileSeq seq(data_dir, "a", 16 * 1024);
+
+    std::string line1("A purely peer-to-peer version of electronic cash would allow online "
+                      "payments to be sent directly from one party to another without going "
+                      "through a financial institution.");
+    std::string line2("Digital signatures provide part of the solution, but the main benefits are "
+                      "lost if a trusted third party is still required to prevent double-spending.");
+
+    size_t pos1 = 0;
+    size_t pos2 = pos1 + GetSerializeSize(line1, CLIENT_VERSION);
+
+    // Write first line to file.
+    {
+        CAutoFile file(seq.Open(FlatFilePos(0, pos1)), SER_DISK, CLIENT_VERSION);
+        file << LIMITED_STRING(line1, 256);
+    }
+
+    // Attempt to append to file opened in read-only mode.
+    {
+        CAutoFile file(seq.Open(FlatFilePos(0, pos2), true), SER_DISK, CLIENT_VERSION);
+        BOOST_CHECK_THROW(file << LIMITED_STRING(line2, 256), std::ios_base::failure);
+    }
+
+    // Append second line to file.
+    {
+        CAutoFile file(seq.Open(FlatFilePos(0, pos2)), SER_DISK, CLIENT_VERSION);
+        file << LIMITED_STRING(line2, 256);
+    }
+
+    // Read text from file in read-only mode.
+    {
+        std::string text;
+        CAutoFile file(seq.Open(FlatFilePos(0, pos1), true), SER_DISK, CLIENT_VERSION);
+
+        file >> LIMITED_STRING(text, 256);
+        BOOST_CHECK_EQUAL(text, line1);
+
+        file >> LIMITED_STRING(text, 256);
+        BOOST_CHECK_EQUAL(text, line2);
+    }
+
+    // Read text from file with position offset.
+    {
+        std::string text;
+        CAutoFile file(seq.Open(FlatFilePos(0, pos2)), SER_DISK, CLIENT_VERSION);
+
+        file >> LIMITED_STRING(text, 256);
+        BOOST_CHECK_EQUAL(text, line2);
+    }
+
+    // Ensure another file in the sequence has no data.
+    {
+        std::string text;
+        CAutoFile file(seq.Open(FlatFilePos(1, pos2)), SER_DISK, CLIENT_VERSION);
+        BOOST_CHECK_THROW(file >> LIMITED_STRING(text, 256), std::ios_base::failure);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(flatfile_allocate)
+{
+    auto data_dir = SetDataDir("flatfile_test");
+    FlatFileSeq seq(data_dir, "a", 100);
+
+    bool out_of_space;
+
+    BOOST_CHECK_EQUAL(seq.Allocate(FlatFilePos(0, 0), 1, out_of_space), 100);
+    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 0))), 100);
+    BOOST_CHECK(!out_of_space);
+
+    BOOST_CHECK_EQUAL(seq.Allocate(FlatFilePos(0, 99), 1, out_of_space), 0);
+    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 99))), 100);
+    BOOST_CHECK(!out_of_space);
+
+    BOOST_CHECK_EQUAL(seq.Allocate(FlatFilePos(0, 99), 2, out_of_space), 101);
+    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 99))), 200);
+    BOOST_CHECK(!out_of_space);
+}
+
+BOOST_AUTO_TEST_CASE(flatfile_flush)
+{
+    auto data_dir = SetDataDir("flatfile_test");
+    FlatFileSeq seq(data_dir, "a", 100);
+
+    bool out_of_space;
+    seq.Allocate(FlatFilePos(0, 0), 1, out_of_space);
+
+    // Flush without finalize should not truncate file.
+    seq.Flush(FlatFilePos(0, 1));
+    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 1))), 100);
+
+    // Flush with finalize should truncate file.
+    seq.Flush(FlatFilePos(0, 1), true);
+    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 1))), 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -4,7 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <util/system.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <string>
 #include <vector>

--- a/src/test/hash_tests.cpp
+++ b/src/test/hash_tests.cpp
@@ -6,7 +6,7 @@
 #include <crypto/siphash.h>
 #include <hash.h>
 #include <util/strencodings.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <vector>
 

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -10,7 +10,7 @@
 #include <key_io.h>
 #include <script/script.h>
 #include <util/strencodings.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -10,7 +10,7 @@
 #include <uint256.h>
 #include <util/system.h>
 #include <util/strencodings.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <string>
 #include <vector>

--- a/src/test/limitedmap_tests.cpp
+++ b/src/test/limitedmap_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <limitedmap.h>
 
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -7,7 +7,7 @@
 #include <validation.h>
 #include <net.h>
 
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/signals2/signal.hpp>
 #include <boost/test/unit_test.hpp>

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -7,7 +7,7 @@
 #include <txmempool.h>
 #include <util/system.h>
 
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 #include <list>

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -4,7 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/merkle.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/merkleblock_tests.cpp
+++ b/src/test/merkleblock_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <merkleblock.h>
 #include <uint256.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -20,7 +20,7 @@
 #include <util/strencodings.h>
 #include <pow.h>
 
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <memory>
 

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -12,7 +12,7 @@
 #include <script/sign.h>
 #include <script/ismine.h>
 #include <uint256.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -3,7 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include <addrman.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 #include <string>
 #include <boost/test/unit_test.hpp>
 #include <hash.h>

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -4,7 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <netbase.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 #include <util/strencodings.h>
 
 #include <string>

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -10,7 +10,7 @@
 #include <uint256.h>
 #include <arith_uint256.h>
 #include <version.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <vector>
 

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -9,7 +9,7 @@
 #include <uint256.h>
 #include <util/system.h>
 
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -8,7 +8,7 @@
 #include <pow.h>
 #include <random.h>
 #include <util/system.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -10,7 +10,7 @@
 #include <serialize.h>
 #include <streams.h>
 
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/raii_event_tests.cpp
+++ b/src/test/raii_event_tests.cpp
@@ -13,7 +13,7 @@
 
 #include <support/events.h>
 
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <vector>
 

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <random.h>
 
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/reverselock_tests.cpp
+++ b/src/test/reverselock_tests.cpp
@@ -4,7 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <reverselock.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -10,7 +10,7 @@
 #include <key_io.h>
 #include <netbase.h>
 
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>

--- a/src/test/sanity_tests.cpp
+++ b/src/test/sanity_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <compat/sanity.h>
 #include <key.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -6,7 +6,7 @@
 #include <random.h>
 #include <scheduler.h>
 
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/bind.hpp>
 #include <boost/thread.hpp>

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -13,7 +13,7 @@
 #include <script/script_error.h>
 #include <script/sign.h>
 #include <script/ismine.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <vector>
 

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -9,7 +9,7 @@
 #include <script/script.h>
 #include <script/script_error.h>
 #include <script/standard.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -13,7 +13,7 @@
 #include <script/sign.h>
 #include <util/system.h>
 #include <util/strencodings.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 #include <rpc/server.h>
 
 #if defined(HAVE_CONSENSUS_LIB)

--- a/src/test/scriptnum_tests.cpp
+++ b/src/test/scriptnum_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <test/scriptnum10.h>
 #include <script/script.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 #include <limits.h>

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -6,7 +6,7 @@
 #include <serialize.h>
 #include <streams.h>
 #include <hash.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <stdint.h>
 

--- a/src/test/setup_common.h
+++ b/src/test/setup_common.h
@@ -46,6 +46,11 @@ struct BasicTestingSetup {
 
     explicit BasicTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
     ~BasicTestingSetup();
+	
+	fs::path SetDataDir(const std::string& name);
+
+private:
+    const fs::path m_path_root;
 };
 
 /** Testing setup that configures a complete environment.
@@ -60,7 +65,6 @@ struct CConnmanTest {
 
 class PeerLogicValidation;
 struct TestingSetup: public BasicTestingSetup {
-    fs::path pathTemp;
     boost::thread_group threadGroup;
     CConnman* connman;
     CScheduler scheduler;

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -11,7 +11,7 @@
 #include <script/script.h>
 #include <serialize.h>
 #include <streams.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 #include <util/system.h>
 #include <util/strencodings.h>
 #include <version.h>

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -10,7 +10,7 @@
 #include <script/script.h>
 #include <script/standard.h>
 #include <uint256.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <vector>
 

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <chain.h>
 #include <util/system.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <vector>
 

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <streams.h>
 #include <support/allocators/zeroafterfree.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/assign/std/vector.hpp> // for 'operator+=()'
 #include <boost/test/unit_test.hpp>

--- a/src/test/sync_tests.cpp
+++ b/src/test/sync_tests.cpp
@@ -3,7 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
  #include <sync.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
  #include <boost/test/unit_test.hpp>
  namespace {
 template <typename MutexType>

--- a/src/test/timedata_tests.cpp
+++ b/src/test/timedata_tests.cpp
@@ -4,7 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 //
 #include <timedata.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/torcontrol_tests.cpp
+++ b/src/test/torcontrol_tests.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 //
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 #include <torcontrol.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <test/data/tx_invalid.json.h>
 #include <test/data/tx_valid.json.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <clientversion.h>
 #include <checkqueue.h>

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <index/txindex.h>
 #include <script/standard.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 #include <util/system.h>
 #include <util/time.h>
 #include <validation.h>

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -9,7 +9,7 @@
 #include <consensus/validation.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -12,7 +12,7 @@
 #include <random.h>
 #include <script/standard.h>
 #include <script/sign.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 #include <util/time.h>
 #include <core_io.h>
 #include <keystore.h>

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -5,7 +5,7 @@
 #include <arith_uint256.h>
 #include <uint256.h>
 #include <version.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 #include <stdint.h>

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -10,7 +10,7 @@
 #include <sync.h>
 #include <util/strencodings.h>
 #include <util/moneystr.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <stdint.h>
 #include <vector>
@@ -1100,7 +1100,7 @@ static void TestOtherProcess(fs::path dirname, std::string lockname, int fd)
 
 BOOST_AUTO_TEST_CASE(test_LockDirectory)
 {
-    fs::path dirname = fs::temp_directory_path() / fs::unique_path();
+    fs::path dirname = SetDataDir("test_LockDirectory") / fs::unique_path();
     const std::string lockname = ".lock";
 #ifndef WIN32
     // Revert SIGCHLD to default, otherwise boost.test will catch and fail on
@@ -1188,12 +1188,12 @@ BOOST_AUTO_TEST_CASE(test_LockDirectory)
 
 BOOST_AUTO_TEST_CASE(test_DirIsWritable)
 {
-    // Should be able to write to the system tmp dir.
-    fs::path tmpdirname = fs::temp_directory_path();
+    // Should be able to write to the data dir.
+    fs::path tmpdirname = SetDataDir("test_DirIsWritable");
     BOOST_CHECK_EQUAL(DirIsWritable(tmpdirname), true);
 
     // Should not be able to write to a non-existent dir.
-    tmpdirname = fs::temp_directory_path() / fs::unique_path();
+    tmpdirname = tmpdirname / fs::unique_path();
     BOOST_CHECK_EQUAL(DirIsWritable(tmpdirname), false);
 
     fs::create_directory(tmpdirname);

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -11,7 +11,7 @@
 #include <miner.h>
 #include <pow.h>
 #include <random.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 #include <validation.h>
 #include <validationinterface.h>
 

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <chain.h>
 #include <versionbits.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 #include <chainparams.h>
 #include <validation.h>
 #include <consensus/params.h>

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -194,6 +194,14 @@ bool DirIsWritable(const fs::path& directory)
     return true;
 }
 
+bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes)
+{
+    constexpr uint64_t min_disk_space = 52428800; // 50 MiB
+
+    uint64_t free_bytes_available = fs::space(dir).available;
+    return free_bytes_available >= min_disk_space + additional_bytes;
+}
+
 /**
  * Interpret a string argument as a boolean.
  *

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -79,6 +79,7 @@ void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length);
 bool RenameOver(fs::path src, fs::path dest);
 bool LockDirectory(const fs::path& directory, const std::string lockfile_name, bool probe_only=false);
 bool DirIsWritable(const fs::path& directory);
+bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes = 0);
 
 /** Release all directory locks. This is used for unit testing only, at runtime
  * the global destructor will take care of the locks.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -16,6 +16,7 @@
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <cuckoocache.h>
+#include <flatfile.h>
 #include <hash.h>
 #include <index/txindex.h>
 #include <policy/fees.h>
@@ -167,7 +168,7 @@ public:
      * that it doesn't descend from an invalid block, and then add it to mapBlockIndex.
      */
     bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex);
-    bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const CDiskBlockPos* dbp, bool* fNewBlock);
+    bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock);
 
     // Block (dis)connection on a given view:
     DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view);
@@ -206,7 +207,7 @@ private:
 
     void InvalidBlockFound(CBlockIndex *pindex, const CValidationState &state);
     CBlockIndex* FindMostWorkChain();
-    void ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pindexNew, const CDiskBlockPos& pos, const Consensus::Params& consensusParams);
+    void ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pindexNew, const FlatFilePos& pos, const Consensus::Params& consensusParams);
 
 
     bool RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& inputs, const CChainParams& params);
@@ -311,7 +312,9 @@ static bool FlushStateToDisk(const CChainParams& chainParams, CValidationState &
 static void FindFilesToPruneManual(std::set<int>& setFilesToPrune, int nManualPruneHeight);
 static void FindFilesToPrune(std::set<int>& setFilesToPrune, uint64_t nPruneAfterHeight);
 bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, bool fScriptChecks, unsigned int flags, bool cacheSigStore, bool cacheFullScriptStore, PrecomputedTransactionData& txdata, std::vector<CScriptCheck> *pvChecks = nullptr);
-static FILE* OpenUndoFile(const CDiskBlockPos &pos, bool fReadOnly = false);
+static FILE* OpenUndoFile(const FlatFilePos &pos, bool fReadOnly = false);
+static FlatFileSeq BlockFileSeq();
+static FlatFileSeq UndoFileSeq();
 
 bool CheckFinalTx(const CTransaction &tx, int flags)
 {
@@ -1074,7 +1077,7 @@ bool GetTransaction(const uint256& hash, CTransactionRef& txOut, const Consensus
 // CBlock and CBlockIndex
 //
 
-static bool WriteBlockToDisk(const CBlock& block, CDiskBlockPos& pos, const CMessageHeader::MessageStartChars& messageStart)
+static bool WriteBlockToDisk(const CBlock& block, FlatFilePos& pos, const CMessageHeader::MessageStartChars& messageStart)
 {
     // Open history file to append
     CAutoFile fileout(OpenBlockFile(pos), SER_DISK, CLIENT_VERSION);
@@ -1095,7 +1098,7 @@ static bool WriteBlockToDisk(const CBlock& block, CDiskBlockPos& pos, const CMes
     return true;
 }
 
-bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, const Consensus::Params& consensusParams)
+bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams)
 {
     block.SetNull();
 
@@ -1121,7 +1124,7 @@ bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, const Consensus:
 
 bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams)
 {
-    CDiskBlockPos blockPos;
+    FlatFilePos blockPos;
     {
         LOCK(cs_main);
         blockPos = pindex->GetBlockPos();
@@ -1135,9 +1138,9 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus
     return true;
 }
 
-bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CDiskBlockPos& pos, const CMessageHeader::MessageStartChars& message_start)
+bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start)
 {
-    CDiskBlockPos hpos = pos;
+    FlatFilePos hpos = pos;
     hpos.nPos -= 8; // Seek back 8 bytes for meta header
     CAutoFile filein(OpenBlockFile(hpos, true), SER_DISK, CLIENT_VERSION);
     if (filein.IsNull()) {
@@ -1172,7 +1175,7 @@ bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CDiskBlockPos& pos,
 
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CBlockIndex* pindex, const CMessageHeader::MessageStartChars& message_start)
 {
-    CDiskBlockPos block_pos;
+    FlatFilePos block_pos;
     {
         LOCK(cs_main);
         block_pos = pindex->GetBlockPos();
@@ -1500,7 +1503,7 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsVi
 
 namespace {
 
-bool UndoWriteToDisk(const CBlockUndo& blockundo, CDiskBlockPos& pos, const uint256& hashBlock, const CMessageHeader::MessageStartChars& messageStart)
+bool UndoWriteToDisk(const CBlockUndo& blockundo, FlatFilePos& pos, const uint256& hashBlock, const CMessageHeader::MessageStartChars& messageStart)
 {
     // Open history file to append
     CAutoFile fileout(OpenUndoFile(pos), SER_DISK, CLIENT_VERSION);
@@ -1529,7 +1532,7 @@ bool UndoWriteToDisk(const CBlockUndo& blockundo, CDiskBlockPos& pos, const uint
 
 static bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex *pindex)
 {
-    CDiskBlockPos pos = pindex->GetUndoPos();
+    FlatFilePos pos = pindex->GetUndoPos();
     if (pos.IsNull()) {
         return error("%s: no undo data available", __func__);
     }
@@ -1675,37 +1678,25 @@ void static FlushBlockFile(bool fFinalize = false)
 {
     LOCK(cs_LastBlockFile);
 
-    CDiskBlockPos posOld(nLastBlockFile, 0);
+    FlatFilePos block_pos_old(nLastBlockFile, vinfoBlockFile[nLastBlockFile].nSize);
+    FlatFilePos undo_pos_old(nLastBlockFile, vinfoBlockFile[nLastBlockFile].nUndoSize);
+
     bool status = true;
-
-    FILE *fileOld = OpenBlockFile(posOld);
-    if (fileOld) {
-        if (fFinalize)
-            status &= TruncateFile(fileOld, vinfoBlockFile[nLastBlockFile].nSize);
-        status &= FileCommit(fileOld);
-        fclose(fileOld);
-    }
-
-    fileOld = OpenUndoFile(posOld);
-    if (fileOld) {
-        if (fFinalize)
-            status &= TruncateFile(fileOld, vinfoBlockFile[nLastBlockFile].nUndoSize);
-        status &= FileCommit(fileOld);
-        fclose(fileOld);
-    }
+    status &= BlockFileSeq().Flush(block_pos_old, fFinalize);
+    status &= UndoFileSeq().Flush(undo_pos_old, fFinalize);
 
     if (!status) {
         AbortNode("Flushing block file to disk failed. This is likely the result of an I/O error.");
     }
 }
 
-static bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, unsigned int nAddSize);
+static bool FindUndoPos(CValidationState &state, int nFile, FlatFilePos &pos, unsigned int nAddSize);
 
 static bool WriteUndoDataForBlock(const CBlockUndo& blockundo, CValidationState& state, CBlockIndex* pindex, const CChainParams& chainparams)
 {
     // Write undo information to disk
     if (pindex->GetUndoPos().IsNull()) {
-        CDiskBlockPos _pos;
+        FlatFilePos _pos;
         if (!FindUndoPos(state, pindex->nFile, _pos, ::GetSerializeSize(blockundo, SER_DISK, CLIENT_VERSION) + 40))
             return error("ConnectBlock(): FindUndoPos failed");
         if (!UndoWriteToDisk(blockundo, _pos, pindex->pprev->GetBlockHash(), chainparams.MessageStart()))
@@ -2182,8 +2173,9 @@ bool static FlushStateToDisk(const CChainParams& chainparams, CValidationState &
         // Write blocks and block index to disk.
         if (fDoFullFlush || fPeriodicWrite) {
             // Depend on nMinDiskSpace to ensure we can write block index
-            if (!CheckDiskSpace(0, true))
-                return state.Error("out of disk space");
+            if (!CheckDiskSpace(GetBlocksDir())) {
+                return AbortNode(state, "Disk space is low!", _("Error: Disk space is low!"));
+            }
             // First make sure all block and undo data is flushed to disk.
             FlushBlockFile();
             // Then update all block file information (which may refer to block and undo files).
@@ -2216,8 +2208,9 @@ bool static FlushStateToDisk(const CChainParams& chainparams, CValidationState &
             // twice (once in the log, and once in the tables). This is already
             // an overestimation, as most will delete an existing entry or
             // overwrite one. Still, use a conservative safety factor of 2.
-            if (!CheckDiskSpace(48 * 2 * 2 * pcoinsTip->GetCacheSize()))
-                return state.Error("out of disk space");
+            if (!CheckDiskSpace(GetDataDir(), 48 * 2 * 2 * pcoinsTip->GetCacheSize())) {
+                return AbortNode(state, "Disk space is low!", _("Error: Disk space is low!"));
+            }
             // Flush the chainstate (which may refer to block index entries).
             if (!pcoinsTip->Flush())
                 return AbortNode(state, "Failed to write to coin database");
@@ -2973,7 +2966,7 @@ CBlockIndex* CChainState::AddToBlockIndex(const CBlockHeader& block)
 }
 
 /** Mark a block as having its data received and checked (up to BLOCK_VALID_TRANSACTIONS). */
-void CChainState::ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pindexNew, const CDiskBlockPos& pos, const Consensus::Params& consensusParams)
+void CChainState::ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pindexNew, const FlatFilePos& pos, const Consensus::Params& consensusParams)
 {
     pindexNew->nTx = block.vtx.size();
     pindexNew->nChainTx = 0;
@@ -3019,7 +3012,7 @@ void CChainState::ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pi
     }
 }
 
-static bool FindBlockPos(CDiskBlockPos &pos, unsigned int nAddSize, unsigned int nHeight, uint64_t nTime, bool fKnown = false)
+static bool FindBlockPos(FlatFilePos &pos, unsigned int nAddSize, unsigned int nHeight, uint64_t nTime, bool fKnown = false)
 {
     LOCK(cs_LastBlockFile);
 
@@ -3054,21 +3047,13 @@ static bool FindBlockPos(CDiskBlockPos &pos, unsigned int nAddSize, unsigned int
         vinfoBlockFile[nFile].nSize += nAddSize;
 
     if (!fKnown) {
-        unsigned int nOldChunks = (pos.nPos + BLOCKFILE_CHUNK_SIZE - 1) / BLOCKFILE_CHUNK_SIZE;
-        unsigned int nNewChunks = (vinfoBlockFile[nFile].nSize + BLOCKFILE_CHUNK_SIZE - 1) / BLOCKFILE_CHUNK_SIZE;
-        if (nNewChunks > nOldChunks) {
-            if (fPruneMode)
-                fCheckForPruning = true;
-            if (CheckDiskSpace(nNewChunks * BLOCKFILE_CHUNK_SIZE - pos.nPos, true)) {
-                FILE *file = OpenBlockFile(pos);
-                if (file) {
-                    LogPrintf("Pre-allocating up to position 0x%x in blk%05u.dat\n", nNewChunks * BLOCKFILE_CHUNK_SIZE, pos.nFile);
-                    AllocateFileRange(file, pos.nPos, nNewChunks * BLOCKFILE_CHUNK_SIZE - pos.nPos);
-                    fclose(file);
-                }
-            }
-            else
-                return error("out of disk space");
+        bool out_of_space;
+        size_t bytes_allocated = BlockFileSeq().Allocate(pos, nAddSize, out_of_space);
+        if (out_of_space) {
+            return AbortNode("Disk space is low!", _("Error: Disk space is low!"));
+        }
+        if (bytes_allocated != 0 && fPruneMode) {
+            fCheckForPruning = true;
         }
     }
 
@@ -3076,32 +3061,23 @@ static bool FindBlockPos(CDiskBlockPos &pos, unsigned int nAddSize, unsigned int
     return true;
 }
 
-static bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, unsigned int nAddSize)
+static bool FindUndoPos(CValidationState &state, int nFile, FlatFilePos &pos, unsigned int nAddSize)
 {
     pos.nFile = nFile;
 
     LOCK(cs_LastBlockFile);
 
-    unsigned int nNewSize;
     pos.nPos = vinfoBlockFile[nFile].nUndoSize;
-    nNewSize = vinfoBlockFile[nFile].nUndoSize += nAddSize;
+    vinfoBlockFile[nFile].nUndoSize += nAddSize;
     setDirtyFileInfo.insert(nFile);
 
-    unsigned int nOldChunks = (pos.nPos + UNDOFILE_CHUNK_SIZE - 1) / UNDOFILE_CHUNK_SIZE;
-    unsigned int nNewChunks = (nNewSize + UNDOFILE_CHUNK_SIZE - 1) / UNDOFILE_CHUNK_SIZE;
-    if (nNewChunks > nOldChunks) {
-        if (fPruneMode)
-            fCheckForPruning = true;
-        if (CheckDiskSpace(nNewChunks * UNDOFILE_CHUNK_SIZE - pos.nPos, true)) {
-            FILE *file = OpenUndoFile(pos);
-            if (file) {
-                LogPrintf("Pre-allocating up to position 0x%x in rev%05u.dat\n", nNewChunks * UNDOFILE_CHUNK_SIZE, pos.nFile);
-                AllocateFileRange(file, pos.nPos, nNewChunks * UNDOFILE_CHUNK_SIZE - pos.nPos);
-                fclose(file);
-            }
-        }
-        else
-            return state.Error("out of disk space");
+    bool out_of_space;
+    size_t bytes_allocated = UndoFileSeq().Allocate(pos, nAddSize, out_of_space);
+    if (out_of_space) {
+        return AbortNode(state, "Disk space is low!", _("Error: Disk space is low!"));
+    }
+    if (bytes_allocated != 0 && fPruneMode) {
+        fCheckForPruning = true;
     }
 
     return true;
@@ -3517,26 +3493,26 @@ bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& headers, CValidatio
 }
 
 /** Store block on disk. If dbp is non-nullptr, the file is known to already reside on disk */
-static CDiskBlockPos SaveBlockToDisk(const CBlock& block, int nHeight, const CChainParams& chainparams, const CDiskBlockPos* dbp) {
+static FlatFilePos SaveBlockToDisk(const CBlock& block, int nHeight, const CChainParams& chainparams, const FlatFilePos* dbp) {
     unsigned int nBlockSize = ::GetSerializeSize(block, SER_DISK, CLIENT_VERSION);
-    CDiskBlockPos blockPos;
+    FlatFilePos blockPos;
     if (dbp != nullptr)
         blockPos = *dbp;
     if (!FindBlockPos(blockPos, nBlockSize+8, nHeight, block.GetBlockTime(), dbp != nullptr)) {
         error("%s: FindBlockPos failed", __func__);
-        return CDiskBlockPos();
+        return FlatFilePos();
     }
     if (dbp == nullptr) {
         if (!WriteBlockToDisk(block, blockPos, chainparams.MessageStart())) {
             AbortNode("Failed to write block");
-            return CDiskBlockPos();
+            return FlatFilePos();
         }
     }
     return blockPos;
 }
 
 /** Store block on disk. If dbp is non-nullptr, the file is known to already reside on disk */
-bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const CDiskBlockPos* dbp, bool* fNewBlock)
+bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock)
 {
     const CBlock& block = *pblock;
 
@@ -3598,7 +3574,7 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
 
     // Write block to history file
     try {
-        CDiskBlockPos blockPos = SaveBlockToDisk(block, pindex->nHeight, chainparams, dbp);
+        FlatFilePos blockPos = SaveBlockToDisk(block, pindex->nHeight, chainparams, dbp);
         if (blockPos.IsNull()) {
             state.Error(strprintf("%s: Failed to find position to write new block to disk", __func__));
             return false;
@@ -3728,9 +3704,9 @@ void PruneOneBlockFile(const int fileNumber)
 void UnlinkPrunedFiles(const std::set<int>& setFilesToPrune)
 {
     for (std::set<int>::iterator it = setFilesToPrune.begin(); it != setFilesToPrune.end(); ++it) {
-        CDiskBlockPos pos(*it, 0);
-        fs::remove(GetBlockPosFilename(pos, "blk"));
-        fs::remove(GetBlockPosFilename(pos, "rev"));
+        FlatFilePos pos(*it, 0);
+        fs::remove(BlockFileSeq().FileName(pos));
+        fs::remove(UndoFileSeq().FileName(pos));
         LogPrintf("Prune: %s deleted blk/rev (%05u)\n", __func__, *it);
     }
 }
@@ -3829,52 +3805,28 @@ static void FindFilesToPrune(std::set<int>& setFilesToPrune, uint64_t nPruneAfte
            nLastBlockWeCanPrune, count);
 }
 
-bool CheckDiskSpace(uint64_t nAdditionalBytes, bool blocks_dir)
+static FlatFileSeq BlockFileSeq()
 {
-    uint64_t nFreeBytesAvailable = fs::space(blocks_dir ? GetBlocksDir() : GetDataDir()).available;
-
-    // Check for nMinDiskSpace bytes (currently 50MB)
-    if (nFreeBytesAvailable < nMinDiskSpace + nAdditionalBytes)
-        return AbortNode("Disk space is low!", _("Error: Disk space is low!"));
-
-    return true;
+    return FlatFileSeq(GetBlocksDir(), "blk", BLOCKFILE_CHUNK_SIZE);
 }
 
-static FILE* OpenDiskFile(const CDiskBlockPos &pos, const char *prefix, bool fReadOnly)
+static FlatFileSeq UndoFileSeq()
 {
-    if (pos.IsNull())
-        return nullptr;
-    fs::path path = GetBlockPosFilename(pos, prefix);
-    fs::create_directories(path.parent_path());
-    FILE* file = fsbridge::fopen(path, fReadOnly ? "rb": "rb+");
-    if (!file && !fReadOnly)
-        file = fsbridge::fopen(path, "wb+");
-    if (!file) {
-        LogPrintf("Unable to open file %s\n", path.string());
-        return nullptr;
-    }
-    if (pos.nPos) {
-        if (fseek(file, pos.nPos, SEEK_SET)) {
-            LogPrintf("Unable to seek to position %u of %s\n", pos.nPos, path.string());
-            fclose(file);
-            return nullptr;
-        }
-    }
-    return file;
+    return FlatFileSeq(GetBlocksDir(), "rev", UNDOFILE_CHUNK_SIZE);;
 }
 
-FILE* OpenBlockFile(const CDiskBlockPos &pos, bool fReadOnly) {
-    return OpenDiskFile(pos, "blk", fReadOnly);
+FILE* OpenBlockFile(const FlatFilePos &pos, bool fReadOnly) {
+    return BlockFileSeq().Open(pos, fReadOnly);
 }
 
 /** Open an undo file (rev?????.dat) */
-static FILE* OpenUndoFile(const CDiskBlockPos &pos, bool fReadOnly) {
-    return OpenDiskFile(pos, "rev", fReadOnly);
+static FILE* OpenUndoFile(const FlatFilePos &pos, bool fReadOnly) {
+    return UndoFileSeq().Open(pos, fReadOnly);
 }
 
-fs::path GetBlockPosFilename(const CDiskBlockPos &pos, const char *prefix)
+fs::path GetBlockPosFilename(const FlatFilePos &pos)
 {
-    return GetBlocksDir() / strprintf("%s%05u.dat", prefix, pos.nFile);
+    return BlockFileSeq().FileName(pos);
 }
 
 CBlockIndex * CChainState::InsertBlockIndex(const uint256& hash)
@@ -3995,7 +3947,7 @@ bool static LoadBlockIndexDB(const CChainParams& chainparams)
     }
     for (std::set<int>::iterator it = setBlkDataFiles.begin(); it != setBlkDataFiles.end(); it++)
     {
-        CDiskBlockPos pos(*it, 0);
+        FlatFilePos pos(*it, 0);
         if (CAutoFile(OpenBlockFile(pos, true), SER_DISK, CLIENT_VERSION).IsNull()) {
             return false;
         }
@@ -4421,7 +4373,7 @@ bool CChainState::LoadGenesisBlock(const CChainParams& chainparams)
 
     try {
         CBlock &block = const_cast<CBlock&>(chainparams.GenesisBlock());
-        CDiskBlockPos blockPos = SaveBlockToDisk(block, 0, chainparams, nullptr);
+        FlatFilePos blockPos = SaveBlockToDisk(block, 0, chainparams, nullptr);
         if (blockPos.IsNull())
             return error("%s: writing genesis block to disk failed", __func__);
         CBlockIndex *pindex = AddToBlockIndex(block);
@@ -4438,10 +4390,10 @@ bool LoadGenesisBlock(const CChainParams& chainparams)
     return g_chainstate.LoadGenesisBlock(chainparams);
 }
 
-bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskBlockPos *dbp)
+bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, FlatFilePos *dbp)
 {
     // Map of disk positions for blocks with unknown parent (only used for reindex)
-    static std::multimap<uint256, CDiskBlockPos> mapBlocksUnknownParent;
+    static std::multimap<uint256, FlatFilePos> mapBlocksUnknownParent;
     int64_t nStart = GetTimeMillis();
 
     int nLoaded = 0;
@@ -4527,9 +4479,9 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
                 while (!queue.empty()) {
                     uint256 head = queue.front();
                     queue.pop_front();
-                    std::pair<std::multimap<uint256, CDiskBlockPos>::iterator, std::multimap<uint256, CDiskBlockPos>::iterator> range = mapBlocksUnknownParent.equal_range(head);
+                    std::pair<std::multimap<uint256, FlatFilePos>::iterator, std::multimap<uint256, FlatFilePos>::iterator> range = mapBlocksUnknownParent.equal_range(head);
                     while (range.first != range.second) {
-                        std::multimap<uint256, CDiskBlockPos>::iterator it = range.first;
+                        std::multimap<uint256, FlatFilePos>::iterator it = range.first;
                         std::shared_ptr<CBlock> pblockrecursive = std::make_shared<CBlock>();
                         if (ReadBlockFromDisk(*pblockrecursive, it->second, chainparams.GetConsensus()))
                         {

--- a/src/validation.h
+++ b/src/validation.h
@@ -198,9 +198,6 @@ extern arith_uint256 nMinimumChainWork;
 /** Best header we've seen so far (used for getheaders queries' starting points). */
 extern CBlockIndex *pindexBestHeader;
 
-/** Minimum disk space required - used in CheckDiskSpace() */
-static const uint64_t nMinDiskSpace = 52428800;
-
 /** Pruning-related variables and constants */
 /** True if any block files have ever been pruned. */
 extern bool fHavePruned;
@@ -262,14 +259,12 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
  */
 bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& block, CValidationState& state, const CChainParams& chainparams, const CBlockIndex** ppindex=nullptr, CBlockHeader *first_invalid=nullptr);
 
-/** Check whether enough disk space is available for an incoming block */
-bool CheckDiskSpace(uint64_t nAdditionalBytes = 0, bool blocks_dir = false);
 /** Open a block file (blk?????.dat) */
-FILE* OpenBlockFile(const CDiskBlockPos &pos, bool fReadOnly = false);
+FILE* OpenBlockFile(const FlatFilePos &pos, bool fReadOnly = false);
 /** Translation to a filesystem path */
-fs::path GetBlockPosFilename(const CDiskBlockPos &pos, const char *prefix);
+fs::path GetBlockPosFilename(const FlatFilePos &pos);
 /** Import blocks from an external file */
-bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskBlockPos *dbp = nullptr);
+bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, FlatFilePos *dbp = nullptr);
 /** Ensures we have a genesis block in the block tree, possibly writing one to disk. */
 bool LoadGenesisBlock(const CChainParams& chainparams);
 /** Load the block tree and coins database from disk,
@@ -408,9 +403,9 @@ void InitScriptExecutionCache();
 
 
 /** Functions for disk access for blocks */
-bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, const Consensus::Params& consensusParams);
+bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams);
 bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
-bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CDiskBlockPos& pos, const CMessageHeader::MessageStartChars& message_start);
+bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start);
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CBlockIndex* pindex, const CMessageHeader::MessageStartChars& message_start);
 
 /** Functions for validating blocks and updating the block tree */

--- a/src/validation.h
+++ b/src/validation.h
@@ -83,7 +83,7 @@ static const int MAX_SCRIPTCHECK_THREADS = 16;
 /** -par default (number of script-checking threads, 0 = auto) */
 static const int DEFAULT_SCRIPTCHECK_THREADS = 0;
 /** Number of blocks that can be requested at any given time from a single peer. */
-static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 16;
+static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 256;
 /** Timeout in seconds during which a peer must stall block download progress before being disconnected. */
 static const unsigned int BLOCK_STALLING_TIMEOUT = 2;
 /** Number of headers sent in one getheaders result. We rely on the assumption that if a peer sends
@@ -98,7 +98,7 @@ static const int MAX_BLOCKTXN_DEPTH = 10;
  *  Larger windows tolerate larger download speed differences between peer, but increase the potential
  *  degree of disordering of blocks on disk (which make reindexing and pruning harder). We'll probably
  *  want to make this a per-peer adaptive value at some point. */
-static const unsigned int BLOCK_DOWNLOAD_WINDOW = 1024;
+static const unsigned int BLOCK_DOWNLOAD_WINDOW = 4096;
 /** Time to wait (in seconds) between writing blocks/block index to disk. */
 static const unsigned int DATABASE_WRITE_INTERVAL = 60 * 60;
 /** Time to wait (in seconds) between flushing chainstate to disk. */

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -100,11 +100,7 @@ static void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
     {
         entry.pushKV("blockhash", wtx.hashBlock.GetHex());
         entry.pushKV("blockindex", wtx.nIndex);
-        std::map<uint256, CBlockIndex*>::const_iterator it = mapBlockIndex.find(wtx.hashBlock);
-        if (it != mapBlockIndex.end())
-            entry.push_back(Pair("blocktime", (boost::int64_t)(it->second->nTime)));
-        else
-            throw JSONRPCError(RPC_INTERNAL_ERROR, strprintf("Error: Block hash %s was not found in the block index.", wtx.hashBlock.ToString().c_str()));
+        entry.pushKV("blocktime", LookupBlockIndex(wtx.hashBlock)->GetBlockTime());
     } else {
         entry.pushKV("trusted", wtx.IsTrusted());
     }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -100,7 +100,11 @@ static void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
     {
         entry.pushKV("blockhash", wtx.hashBlock.GetHex());
         entry.pushKV("blockindex", wtx.nIndex);
-        entry.pushKV("blocktime", LookupBlockIndex(wtx.hashBlock)->GetBlockTime());
+        std::map<uint256, CBlockIndex*>::const_iterator it = mapBlockIndex.find(wtx.hashBlock);
+        if (it != mapBlockIndex.end())
+            entry.push_back(Pair("blocktime", (boost::int64_t)(it->second->nTime)));
+        else
+            throw JSONRPCError(RPC_INTERNAL_ERROR, strprintf("Error: Block hash %s was not found in the block index.", wtx.hashBlock.ToString().c_str()));
     } else {
         entry.pushKV("trusted", wtx.IsTrusted());
     }

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -9,7 +9,7 @@
 #include <amount.h>
 #include <primitives/transaction.h>
 #include <random.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 #include <wallet/test/wallet_test_fixture.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/wallet/test/wallet_crypto_tests.cpp
+++ b/src/wallet/test/wallet_crypto_tests.cpp
@@ -3,7 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 #include <util/strencodings.h>
 #include <wallet/crypter.h>
 

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -6,7 +6,7 @@
 #ifndef VERGE_WALLET_TEST_WALLET_TEST_FIXTURE_H
 #define VERGE_WALLET_TEST_WALLET_TEST_FIXTURE_H
 
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 
 #include <wallet/wallet.h>
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -13,7 +13,7 @@
 
 #include <consensus/validation.h>
 #include <rpc/server.h>
-#include <test/test_verge.h>
+#include <test/setup_common.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/test/wallet_test_fixture.h>
@@ -135,6 +135,8 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
     m_coinbase_txns.emplace_back(CreateAndProcessBlock({}, GetScriptForRawPubKey(coinbaseKey.GetPubKey())).vtx[0]);
 
     LOCK(cs_main);
+	
+	std::string backup_file = (SetDataDir("importwallet_rescan") / "wallet.backup").string();
 
     // Import key into wallet and call dumpwallet to create backup file.
     {
@@ -145,7 +147,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
 
         JSONRPCRequest request;
         request.params.setArray();
-        request.params.push_back((pathTemp / "wallet.backup").string());
+        request.params.push_back(backup_file);
         AddWallet(wallet);
         ::dumpwallet(request);
         RemoveWallet(wallet);
@@ -158,7 +160,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
 
         JSONRPCRequest request;
         request.params.setArray();
-        request.params.push_back((pathTemp / "wallet.backup").string());
+        request.params.push_back(backup_file);
         AddWallet(wallet);
         ::importwallet(request);
         RemoveWallet(wallet);


### PR DESCRIPTION
This cleans up and refactors block file helpers so that they may be used by the block filter indexer.

<!--- Provide a general summary of your changes in the Title above -->

## Description
-refactor of block logic
-uses FlatFilePos and eliminates CDiskBlockPos
-change test_verge to setup_common
- seems to fix reported "LoadExternalBlockFile: Deserialize or I/O error - Read attempted past buffer limit: iostream error" 


## Motivation and Context
updates to recent btc changes, thought it would help some of the block reading issues.

## How Has This Been Tested?
"works on my machine"

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] Mostly costmetic change (fix or feature that is more or less not necessary, lul)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
