### PR TITLE
Re-add new best height checks from v4 instead of nChainWork

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -122,18 +122,7 @@ void CBlockIndex::BuildSkip()
 
 arith_uint256 GetBlockProof(const CBlockIndex& block)
 {
-    arith_uint256 bnTarget;
-    bool fNegative;
-    bool fOverflow;
-    bnTarget.SetCompact(block.nBits, &fNegative, &fOverflow);
-    if (fNegative || fOverflow || bnTarget == 0)
-        return 0;
-    // We need to compute 2**256 / (bnTarget+1), but we can't represent 2**256
-    // as it's too large for an arith_uint256. However, as 2**256 is at least as large
-    // as bnTarget+1, it is equal to ((2**256 - bnTarget - 1) / (bnTarget+1)) + 1,
-    // or ~bnTarget / (bnTarget+1) + 1.
-    // Use weighting system for equivelant algo chainwork
-    return (~bnTarget / (bnTarget + 1)) * GetAlgoWeight(block.GetAlgo()) + 1;
+    return block.nHeight;
 }
 
 int64_t GetBlockProofEquivalentTime(const CBlockIndex& to, const CBlockIndex& from, const CBlockIndex& tip, const Consensus::Params& params)

--- a/src/chain.h
+++ b/src/chain.h
@@ -186,6 +186,10 @@ public:
     unsigned int nUndoPos;
 
     //! (memory only) Total amount of work (expected number of hashes) in the chain up to and including this block
+    /**
+     * CAUTION FOR VERGE THIS IS REPRESENTING THE HEIGHT OF THE BLOCK
+     * FIXME VIP-1
+     */
     arith_uint256 nChainWork;
 
     //! Number of transactions in this block.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -125,7 +125,7 @@ private:
     /** Decreasing counter (used by subsequent preciousblock calls). */
     int32_t nBlockReverseSequenceId = -1;
     /** chainwork for the last block that preciousblock has been applied to. */
-    arith_uint256 nLastPreciousChainwork = 0;
+    arith_uint256 lastPreciousHeight = 0;
 
     /** In order to efficiently track invalidity of headers, we keep the set of
       * blocks which we tried to connect and found to be invalid here (ie which
@@ -2800,11 +2800,11 @@ bool CChainState::PreciousBlock(CValidationState& state, const CChainParams& par
             // Nothing to do, this block is not at the tip.
             return true;
         }
-        if (chainActive.Tip()->nChainWork > nLastPreciousChainwork) {
+        if (chainActive.Tip()->nChainWork > lastPreciousHeight) {
             // The chain has been extended since the last call, reset the counter.
             nBlockReverseSequenceId = -1;
         }
-        nLastPreciousChainwork = chainActive.Tip()->nChainWork;
+        lastPreciousHeight = chainActive.Tip()->nChainWork;
         setBlockIndexCandidates.erase(pindex);
         pindex->nSequenceId = nBlockReverseSequenceId;
         if (nBlockReverseSequenceId > std::numeric_limits<int32_t>::min()) {


### PR DESCRIPTION
### What

V4 basically just puts the block height into the created `nChainWork` of a `CBlockIndex` instead of checking the work it actually did. For now, we'll leave it like this to enable miners in the first place to upgrade to V5 and in the next step #969 (VIP-1) we are going to overhaul and redesign all the chain work checks/algorithms.

 ### Why

Well miners shall be able to upgrade their system first to be able to mine against older version without creating an instant hard fork