### PR TITLE
Update multi-algo template composition

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -76,7 +76,6 @@ static UniValue GetNetworkHashPS(int lookup, int height, int algo = ALGO) {
         return 0;
     
     int64_t timeDiff = maxTime - minTime;
-    printf("work: %s, time: %d", workTotal.GetHex().c_str(), timeDiff);
     workTotal /= GetAlgoWeight(algo); // reverse algo weighting
 
     return workTotal.getdouble() / timeDiff;
@@ -236,27 +235,11 @@ static std::string gbt_vb_name(const Consensus::DeploymentPos pos) {
     return s;
 }
 
-static int32_t determineVersionForBlockTemplate(int32_t algo){
-    switch(algo) {
-        case ALGO_X17:
-            return BLOCK_VERSION_X17;
-        case ALGO_LYRA2RE:
-            return BLOCK_VERSION_LYRA2RE;
-        case ALGO_BLAKE:
-            return BLOCK_VERSION_BLAKE;
-        case ALGO_GROESTL:
-            return BLOCK_VERSION_GROESTL;
-        case ALGO_SCRYPT:
-        default:
-            return BLOCK_VERSION_SCRYPT;
-    }
-}
-
 static UniValue getblocktemplate(const JSONRPCRequest& request)
 {
-    if (request.fHelp || request.params.size() > 1)
+    if (request.fHelp || request.params.size() > 2)
         throw std::runtime_error(
-            "getblocktemplate ( TemplateRequest )\n"
+            "getblocktemplate ( TemplateRequest ) ( algorithm )\n"
             "\nIf the request parameters include a 'mode' key, that is used to explicitly select between the default 'template' request or a 'proposal'.\n"
             "It returns data needed to construct a block to work on.\n"
             "For full specification, see BIPs 22, 23, 9, and 145:\n"
@@ -277,8 +260,8 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
             "           \"support\"          (string) client side supported softfork deployment\n"
             "           ,...\n"
             "       ]\n"
-            "       \"algo\": \"scrypt\"\n"
             "     }\n"
+            "2. algorithm         (string, optional) A string that represents one of the supported algorithms\n"
             "\n"
 
             "\nResult:\n"
@@ -352,7 +335,6 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
         else
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid mode");
         lpval = find_value(oparam, "longpollid");
-        algorithm = find_value(oparam, "algo");
         if (strMode == "proposal")
         {
             const UniValue& dataval = find_value(oparam, "data");
@@ -395,6 +377,10 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
                 nMaxVersionPreVB = uvMaxVersion.get_int64();
             }
         }
+    }
+
+    if(!request.params[1].isNull()) {
+        algorithm = request.params[1].get_str();
     }
 
     if (strMode != "template")
@@ -920,7 +906,7 @@ static const CRPCCommand commands[] =
     { "mining",             "getallnetworkhashps",    &getallnetworkhashps,    {"nblocks","height"} },
     { "mining",             "getmininginfo",          &getmininginfo,          {} },
     { "mining",             "prioritisetransaction",  &prioritisetransaction,  {"txid","dummy","fee_delta"} },
-    { "mining",             "getblocktemplate",       &getblocktemplate,       {"template_request"} },
+    { "mining",             "getblocktemplate",       &getblocktemplate,       {"template_request", "algorithm"} },
     { "mining",             "decodeblock",            &decodeblock,            {"hexdata"} },
     { "mining",             "reserializeblock",       &reserializeblock,       {"hexdata"} },
 


### PR DESCRIPTION
Opens for miners the possibility to choose what algorithm is currently being interesting and they need a template for. With this change, you now can pass a parameter called `algo` into the common request structure to retrieve a block specifically for this algorithm.

Moreover, it is saving them a lot of resources and thus money as they don't have to host 5 different verge nodes. 