### PR TITLE
Upgrade Tor from version 0.3.5.8 to version 0.4.1.6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/tor"]
 	path = src/tor
 	url = https://github.com/torproject/tor/
-	branch = tor-0.3.5.8
+	branch = tor-0.4.1.6

--- a/configure.ac
+++ b/configure.ac
@@ -1411,7 +1411,7 @@ if test x$need_bundled_univalue = xyes; then
 fi
 
 AX_SUBDIRS_CONFIGURE([src/secp256k1], [[--disable-shared], [--with-pic], [--with-bignum=no], [--enable-module-recovery], [--enable-experimental], [--enable-module-ecdh]])
-AX_SUBDIRS_CONFIGURE([src/tor], [[--disable-unittests], [--disable-system-torrc], [--disable-systemd], [--disable-lzma], [--disable-asciidoc], [--with-openssl-dir=$openssl_prefix]])
+AX_SUBDIRS_CONFIGURE([src/tor], [[--disable-system-torrc], [--disable-asciidoc], [--with-openssl-dir=$openssl_prefix]])
 
 AC_OUTPUT
 

--- a/configure.ac
+++ b/configure.ac
@@ -1411,8 +1411,7 @@ if test x$need_bundled_univalue = xyes; then
 fi
 
 AX_SUBDIRS_CONFIGURE([src/secp256k1], [[--disable-shared], [--with-pic], [--with-bignum=no], [--enable-module-recovery], [--enable-experimental], [--enable-module-ecdh]])
-ac_configure_args="${ac_configure_args} --disable-shared --with-pic --with-bignum=no --enable-module-recovery --disable-jni --disable-system-torrc --disable-systemd --disable-lzma --disable-zstd --disable-asciidoc"
-AC_CONFIG_SUBDIRS([src/tor])
+AX_SUBDIRS_CONFIGURE([src/tor], [[--disable-unittests], [--disable-system-torrc], [--disable-systemd], [--disable-lzma], [--disable-asciidoc], [--with-openssl-dir=$openssl_prefix]])
 
 AC_OUTPUT
 

--- a/configure.ac
+++ b/configure.ac
@@ -1411,7 +1411,7 @@ if test x$need_bundled_univalue = xyes; then
 fi
 
 AX_SUBDIRS_CONFIGURE([src/secp256k1], [[--disable-shared], [--with-pic], [--with-bignum=no], [--enable-module-recovery], [--enable-experimental], [--enable-module-ecdh]])
-AX_SUBDIRS_CONFIGURE([src/tor], [[--disable-system-torrc], [--disable-asciidoc], [--with-openssl-dir=$openssl_prefix]])
+AX_SUBDIRS_CONFIGURE([src/tor], [[--disable-system-torrc], [--disable-systemd], [--disable-asciidoc], [--disable-lzma], [--with-openssl-dir=$openssl_prefix], [CFLAGS=-fPIC -O2]])
 
 AC_OUTPUT
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -62,24 +62,21 @@ TOR_UTIL_LIBS = \
 LIBED25519_REF10 = tor/src/ext/ed25519/ref10/libed25519_ref10.a
 LIBED25519_DONNA = tor/src/ext/ed25519/donna/libed25519_donna.a
 LIBKECCAK_TINY = tor/src/ext/keccak-tiny/libkeccak-tiny.a
+
 LIBDONNA = tor/src/lib/libcurve25519_donna.a \
   $(LIBED25519_REF10) \
   $(LIBED25519_DONNA)
 
 TOR_CRYPTO_LIBS = \
-	tor/src/lib/libtor-tls.a \
-	tor/src/lib/libtor-crypt-ops.a \
 	$(LIBKECCAK_TINY) \
 	$(LIBDONNA)
 
 TOR_LIBS = \
 	tor/src/core/libtor-app.a \
-	tor/src/lib/libtor-compress.a \
-	tor/src/lib/libtor-evloop.a \
 	$(TOR_CRYPTO_LIBS) \
 	$(TOR_UTIL_LIBS) \
-	tor/src/trunnel/libor-trunnel.a \
-	tor/src/lib/libtor-trace.a
+  tor/src/trunnel/libor-trunnel.a \
+	tor/src/tools/libtorrunner.a
 
 libverge_SERVER=libverge_server.a
 libverge_COMMON=libverge_common.a

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -27,10 +27,10 @@ VERGE_INCLUDES += $(UNIVALUE_CFLAGS)
 TOR_UTIL_LIBS = \
   tor/src/lib/libtor-buf.a \
   tor/src/lib/libtor-compress.a \
-  tor/src/lib/libtor-container.a \
   tor/src/lib/libtor-crypt-ops.a \
   tor/src/lib/libtor-ctime.a \
   tor/src/lib/libtor-dispatch.a \
+  tor/src/lib/libtor-container.a \
   tor/src/lib/libtor-encoding.a \
   tor/src/lib/libtor-err.a \
   tor/src/lib/libtor-evloop.a \
@@ -73,10 +73,10 @@ TOR_CRYPTO_LIBS = \
 
 TOR_LIBS = \
 	tor/src/core/libtor-app.a \
-	$(TOR_CRYPTO_LIBS) \
+	tor/src/tools/libtorrunner.a \
 	$(TOR_UTIL_LIBS) \
-  tor/src/trunnel/libor-trunnel.a \
-	tor/src/tools/libtorrunner.a
+	$(TOR_CRYPTO_LIBS) \
+  tor/src/trunnel/libor-trunnel.a
 
 libverge_SERVER=libverge_server.a
 libverge_COMMON=libverge_common.a

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,30 +25,39 @@ VERGE_INCLUDES += $(UNIVALUE_CFLAGS)
 
 # "Common" libraries used to link tor's utility code.
 TOR_UTIL_LIBS = \
+  tor/src/lib/libtor-buf.a \
+  tor/src/lib/libtor-compress.a \
+  tor/src/lib/libtor-container.a \
+  tor/src/lib/libtor-crypt-ops.a \
+  tor/src/lib/libtor-ctime.a \
+  tor/src/lib/libtor-dispatch.a \
+  tor/src/lib/libtor-encoding.a \
+  tor/src/lib/libtor-err.a \
+  tor/src/lib/libtor-evloop.a \
+  tor/src/lib/libtor-fdio.a \
+  tor/src/lib/libtor-fs.a \
   tor/src/lib/libtor-geoip.a \
-	tor/src/lib/libtor-process.a \
-	tor/src/lib/libtor-time.a \
-	tor/src/lib/libtor-fs.a \
-	tor/src/lib/libtor-encoding.a \
-	tor/src/lib/libtor-sandbox.a \
-	tor/src/lib/libtor-container.a \
-	tor/src/lib/libtor-net.a \
-	tor/src/lib/libtor-thread.a \
-	tor/src/lib/libtor-memarea.a \
-	tor/src/lib/libtor-math.a \
-	tor/src/lib/libtor-meminfo.a \
-	tor/src/lib/libtor-osinfo.a \
-	tor/src/lib/libtor-log.a \
-	tor/src/lib/libtor-lock.a \
-	tor/src/lib/libtor-fdio.a \
-	tor/src/lib/libtor-string.a \
-	tor/src/lib/libtor-term.a \
-	tor/src/lib/libtor-smartlist-core.a \
-	tor/src/lib/libtor-malloc.a \
-	tor/src/lib/libtor-wallclock.a \
-	tor/src/lib/libtor-err.a \
-	tor/src/lib/libtor-intmath.a \
-	tor/src/lib/libtor-ctime.a
+  tor/src/lib/libtor-intmath.a \
+  tor/src/lib/libtor-lock.a \
+  tor/src/lib/libtor-log.a \
+  tor/src/lib/libtor-malloc.a \
+  tor/src/lib/libtor-math.a \
+  tor/src/lib/libtor-memarea.a \
+  tor/src/lib/libtor-meminfo.a \
+  tor/src/lib/libtor-net.a \
+  tor/src/lib/libtor-osinfo.a \
+  tor/src/lib/libtor-process.a \
+  tor/src/lib/libtor-pubsub.a \
+  tor/src/lib/libtor-sandbox.a \
+  tor/src/lib/libtor-smartlist-core.a \
+  tor/src/lib/libtor-string.a \
+  tor/src/lib/libtor-term.a \
+  tor/src/lib/libtor-thread.a \
+  tor/src/lib/libtor-time.a \
+  tor/src/lib/libtor-tls.a \
+  tor/src/lib/libtor-trace.a \
+  tor/src/lib/libtor-version.a \
+  tor/src/lib/libtor-wallclock.a
 
 LIBED25519_REF10 = tor/src/ext/ed25519/ref10/libed25519_ref10.a
 LIBED25519_DONNA = tor/src/ext/ed25519/donna/libed25519_donna.a

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,8 +29,6 @@ TOR_UTIL_LIBS = \
   tor/src/lib/libtor-compress.a \
   tor/src/lib/libtor-crypt-ops.a \
   tor/src/lib/libtor-ctime.a \
-  tor/src/lib/libtor-dispatch.a \
-  tor/src/lib/libtor-container.a \
   tor/src/lib/libtor-encoding.a \
   tor/src/lib/libtor-err.a \
   tor/src/lib/libtor-evloop.a \
@@ -57,6 +55,8 @@ TOR_UTIL_LIBS = \
   tor/src/lib/libtor-tls.a \
   tor/src/lib/libtor-trace.a \
   tor/src/lib/libtor-version.a \
+  tor/src/lib/libtor-dispatch.a \
+  tor/src/lib/libtor-container.a \
   tor/src/lib/libtor-wallclock.a
 
 LIBED25519_REF10 = tor/src/ext/ed25519/ref10/libed25519_ref10.a

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,39 +25,34 @@ VERGE_INCLUDES += $(UNIVALUE_CFLAGS)
 
 # "Common" libraries used to link tor's utility code.
 TOR_UTIL_LIBS = \
-  tor/src/lib/libtor-buf.a \
-  tor/src/lib/libtor-compress.a \
-  tor/src/lib/libtor-crypt-ops.a \
-  tor/src/lib/libtor-ctime.a \
-  tor/src/lib/libtor-encoding.a \
-  tor/src/lib/libtor-err.a \
-  tor/src/lib/libtor-evloop.a \
-  tor/src/lib/libtor-fdio.a \
-  tor/src/lib/libtor-fs.a \
-  tor/src/lib/libtor-geoip.a \
-  tor/src/lib/libtor-intmath.a \
-  tor/src/lib/libtor-lock.a \
-  tor/src/lib/libtor-log.a \
-  tor/src/lib/libtor-malloc.a \
-  tor/src/lib/libtor-math.a \
-  tor/src/lib/libtor-memarea.a \
-  tor/src/lib/libtor-meminfo.a \
-  tor/src/lib/libtor-net.a \
-  tor/src/lib/libtor-osinfo.a \
-  tor/src/lib/libtor-process.a \
-  tor/src/lib/libtor-pubsub.a \
-  tor/src/lib/libtor-sandbox.a \
-  tor/src/lib/libtor-smartlist-core.a \
-  tor/src/lib/libtor-string.a \
-  tor/src/lib/libtor-term.a \
-  tor/src/lib/libtor-thread.a \
-  tor/src/lib/libtor-time.a \
-  tor/src/lib/libtor-tls.a \
-  tor/src/lib/libtor-trace.a \
-  tor/src/lib/libtor-version.a \
-  tor/src/lib/libtor-dispatch.a \
-  tor/src/lib/libtor-container.a \
-  tor/src/lib/libtor-wallclock.a
+    tor/src/lib/libtor-geoip.a \
+    tor/src/lib/libtor-process.a \
+    tor/src/lib/libtor-buf.a \
+    tor/src/lib/libtor-pubsub.a \
+    tor/src/lib/libtor-dispatch.a \
+    tor/src/lib/libtor-time.a \
+    tor/src/lib/libtor-fs.a \
+    tor/src/lib/libtor-encoding.a \
+    tor/src/lib/libtor-sandbox.a \
+    tor/src/lib/libtor-container.a \
+    tor/src/lib/libtor-net.a \
+    tor/src/lib/libtor-thread.a \
+    tor/src/lib/libtor-memarea.a \
+    tor/src/lib/libtor-math.a \
+    tor/src/lib/libtor-meminfo.a \
+    tor/src/lib/libtor-osinfo.a \
+    tor/src/lib/libtor-log.a \
+    tor/src/lib/libtor-lock.a \
+    tor/src/lib/libtor-fdio.a \
+    tor/src/lib/libtor-string.a \
+    tor/src/lib/libtor-term.a \
+    tor/src/lib/libtor-smartlist-core.a \
+    tor/src/lib/libtor-malloc.a \
+    tor/src/lib/libtor-wallclock.a \
+    tor/src/lib/libtor-err.a \
+    tor/src/lib/libtor-version.a \
+    tor/src/lib/libtor-intmath.a \
+    tor/src/lib/libtor-ctime.a
 
 LIBED25519_REF10 = tor/src/ext/ed25519/ref10/libed25519_ref10.a
 LIBED25519_DONNA = tor/src/ext/ed25519/donna/libed25519_donna.a
@@ -68,15 +63,19 @@ LIBDONNA = tor/src/lib/libcurve25519_donna.a \
   $(LIBED25519_DONNA)
 
 TOR_CRYPTO_LIBS = \
+	tor/src/lib/libtor-tls.a \
+	tor/src/lib/libtor-crypt-ops.a \
 	$(LIBKECCAK_TINY) \
 	$(LIBDONNA)
 
 TOR_LIBS = \
 	tor/src/core/libtor-app.a \
-	tor/src/tools/libtorrunner.a \
-	$(TOR_UTIL_LIBS) \
+	tor/src/lib/libtor-compress.a \
+	tor/src/lib/libtor-evloop.a \
 	$(TOR_CRYPTO_LIBS) \
-  tor/src/trunnel/libor-trunnel.a
+	$(TOR_UTIL_LIBS) \
+	tor/src/trunnel/libor-trunnel.a \
+	tor/src/lib/libtor-trace.a
 
 libverge_SERVER=libverge_server.a
 libverge_COMMON=libverge_common.a


### PR DESCRIPTION
Features:

* upgrades tor to the latest version
* adds the capability for using custom OpenSSL versions and pass it to tor compiling