### PR TITLE
Add protocol version alert when connected to peer

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -235,6 +235,7 @@ VERGE_CORE_H = \
   util/moneystr.h \
   util/time.h \
   validation.h \
+  alerter.h \
   validationinterface.h \
   versionbits.h \
   torcontroller.h \
@@ -305,6 +306,7 @@ libverge_server_a_SOURCES = \
   txmempool.cpp \
   ui_interface.cpp \
   validation.cpp \
+  alerter.cpp \
   validationinterface.cpp \
   versionbits.cpp \
   torcontroller.cpp \

--- a/src/alerter.cpp
+++ b/src/alerter.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2009-2017 The Bitcoin Core developers
+// Copyright (c) 2018-2019 The VERGE Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <alerter.h>
+
+void DoWarning(const std::string& strWarning)
+{
+    static bool fWarned = false;
+    SetMiscWarning(strWarning);
+    if (!fWarned) {
+        AlertNotify(strWarning);
+        fWarned = true;
+    }
+}
+
+void AlertNotify(const std::string& strMessage)
+{
+  uiInterface.NotifyAlertChanged();
+  std::string strCmd = gArgs.GetArg("-alertnotify", "");
+  if (strCmd.empty()) return;
+
+  // Alert text should be plain ascii coming from a trusted source, but to
+  // be safe we first strip anything not in safeChars, then add single quotes around
+  // the whole string before passing it to the shell:
+  std::string singleQuote("'");
+  std::string safeStatus = SanitizeString(strMessage);
+  safeStatus = singleQuote+safeStatus+singleQuote;
+  boost::replace_all(strCmd, "%s", safeStatus);
+
+  std::thread t(runCommand, strCmd);
+  t.detach(); // thread runs free
+}

--- a/src/alerter.h
+++ b/src/alerter.h
@@ -1,0 +1,17 @@
+#ifndef VERGE_ALERTER_H
+#define VERGE_ALERTER_H
+
+#include <warnings.h>
+#include <ui_interface.h>
+#include <util/strencodings.h>
+#include <util/system.h>
+
+#include <boost/algorithm/string/replace.hpp>
+#include <boost/thread.hpp>
+
+
+void DoWarning(const std::string& strWarning);
+
+void AlertNotify(const std::string& strMessage);
+
+#endif // VERGE_ALERTER_H

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -6,6 +6,7 @@
 
 #include <net_processing.h>
 
+#include <alerter.h>
 #include <addrman.h>
 #include <arith_uint256.h>
 #include <blockencodings.h>
@@ -1704,6 +1705,15 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             }
             pfrom->fDisconnect = true;
             return false;
+        }
+
+        if (nVersion > PROTOCOL_VERSION) {
+            DoWarning(
+                strprintf(
+                    "Warning: Unknown protocol version detected (protocol-version %i). Consider checking updates for your wallet.",
+                    nVersion
+                )
+            );
         }
 
         if (nVersion == 10300)


### PR DESCRIPTION
Adds a new alert whenever we met a peer with an unknown higher protocol version that we're able to support. With that we are going to tell the user via `alertnotify`-cmd or visually inside the QT Wallet to manually check for wallet upgrades. (no website or links specified for REASONS.)

What it's not:

* an automatic upgrade mechanism
* referrer to any wesbite to download something
* downgrades compatiblity