### PR TITLE
Add -version option to verge-cli

### DIFF
--- a/src/verge-cli.cpp
+++ b/src/verge-cli.cpp
@@ -51,6 +51,8 @@ static void SetupCliArgs()
     gArgs.AddArg("-rpcwallet=<walletname>", "Send RPC for non-default wallet on RPC server (needs to exactly match corresponding -wallet option passed to verged)", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-stdin", "Read extra arguments from standard input, one per line until EOF/Ctrl-D (recommended for sensitive information such as passphrases).  When combined with -stdinrpcpass, the first line from standard input is used for the RPC password.", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-stdinrpcpass", strprintf("Read RPC password from standard input as a single line.  When combined with -stdin, the first line from standard input is used for the RPC password."), false, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-version", "Print version and exit", false, OptionsCategory::OPTIONS);
+
 
     // Hidden
     gArgs.AddArg("-h", "", false, OptionsCategory::HIDDEN);


### PR DESCRIPTION
## Description
Add the _-version_ option to verge-cli. 
This is useful for administrators and anyone else building automation tasks. It provides consistency with many other coin daemons, simplifying the process of being able to run the same tool against multiple daemons without having to cater for special cases (like getting the version information from the daemon instead).  

## Related Issue
[#1063](https://github.com/vergecurrency/verge/issues/1063)

## Motivation and Context
Makes life easier for automation builders by providing consistency with other coins.

## How Has This Been Tested?
Forked, branched, compiled, tested. The functionality was actually already present in verge-cli; I have just exposed it. The change is self-documenting, as can be seen in the screenshot below 

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/17745270/108639011-8b892400-7492-11eb-8e3d-48154ea80a96.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
