### PR TITLE
Readme.md - Fix broken link to Black Paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Block Number Range | Reward
 * [Blockchain Explorer](https://verge-blockchain.info/)
 * [Blockchain Explorer Testnet](https://testnet.verge-blockchain.info/)
 * [Mining Pool List](https://vergecurrency.com/community/xvg-mining-pools/)
-* [Black Paper](https://vergecurrency.com/static/blackpaper/Verge-Anonymity-Centric-CryptoCurrency.pdf)
+* [Black Paper](https://vergecurrency.com/static/blackpaper/verge-blackpaper-v5.0.pdf)
 
 ### Community
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The current link to the Black Paper is broken (404). I replaced it with the link from the menu of the official site.

## Related Issue
https://github.com/vergecurrency/verge/issues/1106

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Read the Readme
clicked the Black Paper link
## Screenshots (if appropriate):
<img width="982" alt="Screenshot 2023-08-25 at 15 55 21" src="https://github.com/vergecurrency/verge/assets/31593649/621557c2-29a6-431c-acf3-17e7eec927de">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
