### PR TITLE
qt: forward-declare QNetworkProxy in optionsmodel header

### DIFF
--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -10,11 +10,11 @@
 
 #include <QAbstractListModel>
 
-#include <QNetworkProxy>
-
 namespace interfaces {
 class Node;
 }
+
+class QNetworkProxy;
 
 extern const char *DEFAULT_GUI_PROXY_HOST;
 static constexpr unsigned short DEFAULT_GUI_PROXY_PORT = 9050;


### PR DESCRIPTION
### Motivation
- Fix a header-parse/build error where `QNetworkProxy` was not declared when including `src/qt/optionsmodel.h`, which caused compilation failures for the `getProxySettings` declaration.

### Description
- Replace `#include <QNetworkProxy>` in `src/qt/optionsmodel.h` with a forward declaration `class QNetworkProxy;` and retain the full `QtNetwork` include in `src/qt/optionsmodel.cpp` where the type is used.

### Testing
- Attempted to build the depends tree with `cd depends && make -j4 HOST=x86_64-linux-gnu` and to run `./autogen.sh`, but both operations failed due to external network restrictions (HTTP 403) preventing dependency downloads and submodule cloning, so a full project build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1965ed3cc8326b97b71e7acbacf23)