### PR TITLE
  Fix node crash in getblocktemplate: null/uninitialized pblockCache …

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -461,8 +461,8 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
     // Cache whether the last invocation was with segwit support, to avoid returning
     // a segwit-block to a non-segwit caller.
     // static bool fLastTemplateSupportsSegwit = true;
-    CBlock* pblockCache;
-    if (!pblocktemplate){
+    CBlock* pblockCache = nullptr;
+    if (!pblocktemplate) {
         pblockCache = &pblocktemplate->block;
     }
     int32_t templateAlgorithm = algorithm.isStr() ? GetAlgoByName(algorithm.get_str()) : ALGO;


### PR DESCRIPTION
…segfaults any mining node once synced

CBlock* pblockCache was declared uninitialized and only set inside if (!pblocktemplate) - inverted logic that derefs a null unique_ptr when the template IS null, and leaves pblockCache as garbage when the template exists.

During IBD pindexPrev != chainActive.Tip() always fired first, so the pblockCache != nullptr check at the condition below was never reached. After sync, pindexPrev == chainActive.Tip() is true and the code evaluates pblockCache (uninitialized garbage) != nullptr -> true -> pblockCache->GetBlockTime() -> segfault.

Fix: initialize to nullptr and correct the condition to if (pblocktemplate).

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
