### PR TITLE
Trivial: Fix coinbase input comment typo

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -180,7 +180,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     // Create coinbase transaction.
     CMutableTransaction coinbaseTx;
-    // vin emtpy
+    // vin empty
     coinbaseTx.vin.resize(1);
     coinbaseTx.vin[0].prevout.SetNull();
     // vout to miner with subsidy


### PR DESCRIPTION
## Description

Correct `vin emtpy` to `vin empty` in the comment that introduces coinbase transaction input initialization.

## Related Issue

Closes #ISSUE_NUMBER

## Motivation and Context

The existing comment contains a transposed-letter typo next to consensus-sensitive mining code. Correcting it makes the initialization step easier to read without changing behavior.

## How Has This Been Tested?

- `git diff --check`
- No runtime tests were run because this change only updates a comment.

## Screenshots (if appropriate):

Not applicable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.